### PR TITLE
Move parameter_names_to_values from Individual to Genome

### DIFF
--- a/cgp/individual.py
+++ b/cgp/individual.py
@@ -1,16 +1,5 @@
-import collections
-import numpy as np
-
 from .genome import Genome
 from .cartesian_graph import CartesianGraph
-
-
-def return_float_one():
-    """Constructor for default value of defaultdict. Needs to be global to
-    support pickling.
-
-    """
-    return 1.0
 
 
 class Individual:
@@ -29,9 +18,6 @@ class Individual:
         self.genome = genome
         self.idx = None  # an identifier to keep track of all unique genomes
 
-        # dictionary to store values of Parameter nodes
-        self.parameter_names_to_values = collections.defaultdict(return_float_one)
-
     def __repr__(self):
         return f"Individual(idx={self.idx}, fitness={self.fitness}, genome={self.genome}))"
 
@@ -42,13 +28,7 @@ class Individual:
         -------
         Individual
         """
-        new_individual = Individual(self.fitness, self.genome.clone())
-
-        # Lamarckian strategy: parameter values are passed on to
-        # offspring
-        new_individual.parameter_names_to_values = self.parameter_names_to_values.copy()
-
-        return new_individual
+        return Individual(self.fitness, self.genome.clone())
 
     def crossover(self, other_parent, rng):
         """Create a new individual by cross over with another individual.
@@ -120,7 +100,7 @@ class Individual:
         ----------
         Callable
         """
-        return CartesianGraph(self.genome).to_func(self.parameter_names_to_values)
+        return CartesianGraph(self.genome).to_func()
 
     def to_numpy(self):
         """Return the expression represented by the individual as
@@ -130,7 +110,7 @@ class Individual:
         -------
         Callable
         """
-        return CartesianGraph(self.genome).to_numpy(self.parameter_names_to_values)
+        return CartesianGraph(self.genome).to_numpy()
 
     def to_torch(self):
         """Return the expression represented by the individual as Torch class.
@@ -139,7 +119,7 @@ class Individual:
         -------
         torch.nn.Module
         """
-        return CartesianGraph(self.genome).to_torch(self.parameter_names_to_values)
+        return CartesianGraph(self.genome).to_torch()
 
     def to_sympy(self, simplify=True):
         """Return the expression represented by the individual as SymPy
@@ -149,33 +129,13 @@ class Individual:
         -------
         SymPy expression
         """
-        return CartesianGraph(self.genome).to_sympy(simplify, self.parameter_names_to_values)
+        return CartesianGraph(self.genome).to_sympy(simplify)
 
     def update_parameters_from_torch_class(self, torch_cls):
-        """Update values stored in Parameter nodes of graph from parameters of
-        a given Torch instance.  Can be used to import new values from
-        a Torch class after they have been altered, e.g., by local
-        search.
+        any_parameter_updated = self.genome.update_parameters_from_torch_class(torch_cls)
 
-        Parameters
-        ----------
-        torch_cls : torch.nn.module
-            Instance of a torch class.
-
-        Returns
-        -------
-        None
-
-        """
-        for name, value in torch_cls.named_parameters():
-            name = f"<{name[1:]}>"
-            if name in self.parameter_names_to_values:
-                self.parameter_names_to_values[name] = value.item()
-                assert not np.isnan(self.parameter_names_to_values[name])
-
-                # since a parameter of this individual has changed its
-                # fitness needs to be reevaluated
-                self.fitness = None
+        if any_parameter_updated:
+            self.fitness = None
 
 
 class IndividualMultiGenome(Individual):

--- a/test/test_individual.py
+++ b/test/test_individual.py
@@ -47,7 +47,7 @@ def test_individual_with_parameter_python():
     assert y[0] == pytest.approx(x[0] + c)
 
     c = 2.0
-    individual.parameter_names_to_values["<p1>"] = c
+    individual.genome.parameter_names_to_values["<p1>"] = c
 
     f = individual.to_func()
     y = f(x)
@@ -86,7 +86,7 @@ def test_individual_with_parameter_torch():
     assert y[1, 0].item() == pytest.approx(x[1, 0].item() + c)
 
     c = 2.0
-    individual.parameter_names_to_values["<p1>"] = c
+    individual.genome.parameter_names_to_values["<p1>"] = c
 
     f = individual.to_torch()
     y = f(x)
@@ -125,7 +125,7 @@ def test_individual_with_parameter_sympy():
     assert y == pytest.approx(x[0] + c)
 
     c = 2.0
-    individual.parameter_names_to_values["<p1>"] = c
+    individual.genome.parameter_names_to_values["<p1>"] = c
 
     f = individual.to_sympy()[0]
     y = f.subs("x_0", x[0]).evalf()
@@ -195,3 +195,70 @@ def test_to_and_from_torch_plus_backprop():
     f_func = individual.to_func()
     y = f_func(x)
     assert y[0] == pytest.approx(f_target(x[0]))
+
+
+def test_update_parameters_from_torch_class_resets_fitness():
+    pytest.importorskip("torch")
+    primitives = (cgp.Mul, cgp.Parameter)
+    genome = cgp.Genome(1, 1, 2, 1, 1, primitives)
+    # f(x) = c * x
+    genome.dna = [
+        ID_INPUT_NODE,
+        ID_NON_CODING_GENE,
+        ID_NON_CODING_GENE,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1,
+        ID_OUTPUT_NODE,
+        2,
+        ID_NON_CODING_GENE,
+    ]
+    fitness = 1.0
+    individual = Individual(fitness, genome)
+
+    f = individual.to_torch()
+    f._p1.data[0] = math.pi
+
+    assert individual.fitness is not None
+    individual.update_parameters_from_torch_class(f)
+    assert individual.fitness is None
+
+    g = individual.to_func()
+    x = 2.0
+    assert g([x])[0] == pytest.approx(math.pi * x)
+
+
+def test_update_parameters_from_torch_class_does_not_reset_fitness_for_unused_parameters():
+    pytest.importorskip("torch")
+    primitives = (cgp.Mul, cgp.Parameter)
+    genome = cgp.Genome(1, 1, 2, 1, 1, primitives)
+    # f(x) = x ** 2
+    genome.dna = [
+        ID_INPUT_NODE,
+        ID_NON_CODING_GENE,
+        ID_NON_CODING_GENE,
+        1,  # these
+        0,  # three
+        0,  # genes code for an unused parameter node
+        0,
+        0,
+        0,
+        ID_OUTPUT_NODE,
+        2,
+        ID_NON_CODING_GENE,
+    ]
+    fitness = 1.0
+    individual = Individual(fitness, genome)
+
+    f = individual.to_torch()
+
+    assert individual.fitness is not None
+    individual.update_parameters_from_torch_class(f)
+    assert individual.fitness is not None
+
+    g = individual.to_func()
+    x = 2.0
+    assert g([x])[0] == pytest.approx(x ** 2)

--- a/test/test_local_search.py
+++ b/test/test_local_search.py
@@ -19,16 +19,16 @@ def test_gradient_based_step_towards_maximum():
         return torch.nn.MSELoss()(f(x_dummy), target_value)
 
     # test increase parameter value if too small
-    ind.parameter_names_to_values["<p1>"] = 0.9
+    ind.genome.parameter_names_to_values["<p1>"] = 0.9
     cgp.local_search.gradient_based(ind, objective, 0.05, 1)
-    assert ind.parameter_names_to_values["<p1>"] == pytest.approx(0.91)
+    assert ind.genome.parameter_names_to_values["<p1>"] == pytest.approx(0.91)
 
     # test decrease parameter value if too large
-    ind.parameter_names_to_values["<p1>"] = 1.1
+    ind.genome.parameter_names_to_values["<p1>"] = 1.1
     cgp.local_search.gradient_based(ind, objective, 0.05, 1)
-    assert ind.parameter_names_to_values["<p1>"] == pytest.approx(1.09)
+    assert ind.genome.parameter_names_to_values["<p1>"] == pytest.approx(1.09)
 
     # test no change of parameter value if at optimum
-    ind.parameter_names_to_values["<p1>"] = 1.0
+    ind.genome.parameter_names_to_values["<p1>"] = 1.0
     cgp.local_search.gradient_based(ind, objective, 0.05, 1)
-    assert ind.parameter_names_to_values["<p1>"] == pytest.approx(1.0)
+    assert ind.genome.parameter_names_to_values["<p1>"] == pytest.approx(1.0)


### PR DESCRIPTION
As discussed in #97. This dictionary is used to store the values for ParameterNodes appearing in the graph. It is hence closely linked to the specific genome and should hence be managed there.

closes #97 