### PR TITLE
Modify travis config file to add job matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ install:
   - pip install mypy
   - pip install .$DEP
 script:
-  - pytest --cov
   - black --check .
   - flake8 --config=.flake8 .
   - mypy cgp
+  - cd test && pytest --cov=cgp
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,20 @@
-sudo: false
 language: python
 python:
   - "3.6"
   - "3.7"
   - "3.8"
+env:
+  - DEP=[all]
+  - DEP=
 branches:
   only:
     - master
+jobs:
+  exclude:
+  - python: "3.6"
+    env: DEP=
+  - python: "3.7"
+    env: DEP=
 before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
@@ -16,11 +24,10 @@ before_install:
   - source activate myenv
   - pip install --upgrade pip
 install:
-  - pip install -r requirements.txt
   - pip install pytest pytest-cov coveralls
   - pip install flake8 black
-  - pip install .[all]
   - pip install mypy
+  - pip install .$DEP
 script:
   - pytest --cov
   - black --check .

--- a/cgp/cartesian_graph.py
+++ b/cgp/cartesian_graph.py
@@ -309,7 +309,7 @@ def _f(x):
 
     def to_torch(
         self, parameter_names_to_values: Optional[Dict[str, float]] = None
-    ) -> torch.nn.Module:
+    ) -> "torch.nn.Module":
         """Compile the function(s) represented by the graph to a Torch class.
 
         Generates a definition of the Torch class in Python code and
@@ -335,7 +335,7 @@ def _f(x):
                     node.format_parameter_str()
                     all_parameter_str.append(node.parameter_str)
         forward_str = ", ".join(node.output_str for node in self.output_nodes)
-        class_str = f"""\
+        class_str = """\
 class _C(torch.nn.Module):
 
     def __init__(self):
@@ -370,7 +370,7 @@ class _C(torch.nn.Module):
         self,
         simplify: Optional[bool] = True,
         parameter_names_to_values: Optional[Dict[str, float]] = None,
-    ) -> List[sympy_expr.Expr]:
+    ) -> List["sympy_expr.Expr"]:
         """Compile the function(s) represented by the graph to a SymPy expression.
 
         Generates one SymPy expression for each output node.

--- a/cgp/local_search/gradient_based.py
+++ b/cgp/local_search/gradient_based.py
@@ -2,7 +2,7 @@ import numpy as np
 
 try:
     import torch  # noqa: F401
-    from torch.optim.optimizer import Optimizer
+    from torch.optim.optimizer import Optimizer  # noqa: F401
 
     torch_available = True
 except ModuleNotFoundError:
@@ -16,10 +16,10 @@ from ..individual import Individual  # noqa: F401
 
 def gradient_based(
     individual: Individual,
-    objective: Callable[[torch.nn.Module], torch.Tensor],
+    objective: Callable[["torch.nn.Module"], "torch.Tensor"],
     lr: float,
     gradient_steps: int,
-    optimizer: Optional[Optimizer] = None,
+    optimizer: Optional["Optimizer"] = None,
     clip_value: Optional[float] = None,
 ) -> None:
     """Perform a local search for numeric leaf values for an individual

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ def read_extra_requirements():
     extra_requirements = {}
     extra_requirements["all"] = []
     with open("./extra-requirements.txt") as f:
-        for l in f:
-            req = l.replace("\n", " ")
+        for dep in f:
+            req = dep.replace("\n", " ")
             extra_requirements[req] = [req]
             extra_requirements["all"].append(req)
 

--- a/test/test_individual.py
+++ b/test/test_individual.py
@@ -1,7 +1,6 @@
 import math
 import pickle
 import pytest
-import torch
 
 import cgp
 from cgp.individual import Individual
@@ -57,7 +56,7 @@ def test_individual_with_parameter_python():
 
 
 def test_individual_with_parameter_torch():
-
+    torch = pytest.importorskip("torch")
     primitives = (cgp.Add, cgp.Parameter)
     genome = cgp.Genome(1, 1, 2, 1, 2, primitives)
     # f(x) = x + c
@@ -97,7 +96,7 @@ def test_individual_with_parameter_torch():
 
 
 def test_individual_with_parameter_sympy():
-
+    sympy = pytest.importorskip("sympy")  # noqa
     primitives = (cgp.Add, cgp.Parameter)
     genome = cgp.Genome(1, 1, 2, 1, 2, primitives)
     # f(x) = x + c
@@ -135,6 +134,7 @@ def test_individual_with_parameter_sympy():
 
 
 def test_to_and_from_torch_plus_backprop():
+    torch = pytest.importorskip("torch")
     primitives = (cgp.Mul, cgp.Parameter)
     genome = cgp.Genome(1, 1, 2, 2, 1, primitives)
     # f(x) = c * x


### PR DESCRIPTION
This PR adds jobs to the CI that test the libraries without extra requirements. Closes #103 and fixes the detected issues:
- put annotations using optional dependencies in quotation marks
- mark torch- and sympy-dependent tests as skip

It furthermore fixes some minor issues with flake8 and makes `coveralls` actually look at the library, not at the tests.