### PR TITLE
Add type hints to Individual class and fix detected issues

### DIFF
--- a/cgp/ea/mu_plus_lambda.py
+++ b/cgp/ea/mu_plus_lambda.py
@@ -1,9 +1,9 @@
 import concurrent.futures
 import numpy as np
 
-from typing import Callable, List
+from typing import Callable, List, Tuple
 
-from ..individual import Individual
+from ..individual import IndividualBase
 from ..population import Population
 
 
@@ -24,7 +24,7 @@ class MuPlusLambda:
         tournament_size: int,
         *,
         n_processes: int = 1,
-        local_search: Callable[[Individual], None] = lambda combined: None
+        local_search: Callable[[IndividualBase], None] = lambda combined: None,
     ):
         """Init function
 
@@ -59,7 +59,7 @@ class MuPlusLambda:
         self.local_search = local_search
 
     def initialize_fitness_parents(
-        self, pop: Population, objective: Callable[[Individual], Individual]
+        self, pop: Population, objective: Callable[[IndividualBase], IndividualBase]
     ) -> None:
         """Initialize the fitness of all parents in the given population.
 
@@ -67,25 +67,27 @@ class MuPlusLambda:
         ----------
         pop : Population
             Population instance.
-        objective : Callable[[gp.Individual], gp.Individual]
+        objective : Callable[[gp.IndividualBase], gp.IndividualBase]
             An objective function used for the evolution. Needs to take an
-            individual (Individual) as input parameter and return
+            individual (IndividualBase) as input parameter and return
             a modified individual (with updated fitness).
         """
         # TODO can we avoid this function? how should a population be
         # initialized?
         pop._parents = self._compute_fitness(pop.parents, objective)
 
-    def step(self, pop: Population, objective: Callable[[Individual], Individual]) -> Population:
+    def step(
+        self, pop: Population, objective: Callable[[IndividualBase], IndividualBase]
+    ) -> Population:
         """Perform one step in the evolution.
 
         Parameters
         ----------
         pop : Population
             Population instance.
-        objective : Callable[[gp.Individual], gp.Individual]
+        objective : Callable[[gp.IndividualBase], gp.IndividualBase]
             An objective function used for the evolution. Needs to take an
-            individual (Individual) as input parameter and return
+            individual (IndividualBase) as input parameter and return
             a modified individual (with updated fitness).
 
         Returns
@@ -108,7 +110,6 @@ class MuPlusLambda:
 
         for ind in combined:
             self.local_search(ind)
-
         combined = self._compute_fitness(combined, objective)
 
         combined = self._sort(combined)
@@ -117,10 +118,10 @@ class MuPlusLambda:
 
         return pop
 
-    def _create_new_offspring_generation(self, pop: Population) -> List[Individual]:
+    def _create_new_offspring_generation(self, pop: Population) -> List[IndividualBase]:
         # fill breeding pool via tournament selection from parent
         # population
-        breeding_pool: List[Individual] = []
+        breeding_pool: List[IndividualBase] = []
         while len(breeding_pool) < self.n_breeding:
             tournament_pool = pop.rng.permutation(pop.parents)[: self.tournament_size]
             best_in_tournament = sorted(tournament_pool, key=lambda x: -x.fitness)[0]
@@ -137,8 +138,8 @@ class MuPlusLambda:
         return offsprings
 
     def _compute_fitness(
-        self, combined: List[Individual], objective: Callable[[Individual], Individual],
-    ) -> List[Individual]:
+        self, combined: List[IndividualBase], objective: Callable[[IndividualBase], IndividualBase]
+    ) -> List[IndividualBase]:
         # computes fitness on all individuals, objective functions
         # should return immediately if fitness is not None
         if self.n_processes == 1:
@@ -149,7 +150,7 @@ class MuPlusLambda:
 
         return combined
 
-    def _sort(self, combined: List[Individual]) -> List[Individual]:
+    def _sort(self, combined: List[IndividualBase]) -> List[IndividualBase]:
         # create copy of population
         combined_copy = [ind.clone() for ind in combined]
 
@@ -159,20 +160,31 @@ class MuPlusLambda:
             if np.isnan(ind.fitness):
                 ind.fitness = -np.inf
 
-        # get list of indices that sorts combined_copy ("argsort")
+        def sort_func(zipped_ind: Tuple[int, IndividualBase]) -> float:
+            """Return fitness of an individual or raise error if it is None.
+            """
+            _, ind = zipped_ind
+            if isinstance(ind.fitness, float):
+                return ind.fitness
+            else:
+                raise ValueError(
+                    f"IndividualBase fitness value is of wrong type {type(ind.fitness)}."
+                )
+
+        # get list of indices that sorts combined_copy ("argsort") in descending order
         combined_sorted_indices = [
-            idx for (idx, _) in sorted(enumerate(combined_copy), key=lambda x: -x[1].fitness)
+            idx for (idx, _) in sorted(enumerate(combined_copy), key=sort_func, reverse=True)
         ]
 
-        # return sorted original list of individuals
+        # return original list of individuals sorted in descending order
         return [combined[idx] for idx in combined_sorted_indices]
 
     def _create_new_parent_population(
-        self, n_parents: int, combined: List[Individual]
-    ) -> List[Individual]:
+        self, n_parents: int, combined: List[IndividualBase]
+    ) -> List[IndividualBase]:
         # create new parent population by picking the `n_parents` individuals
         # with the highest fitness
-        parents: List[Individual] = []
+        parents: List[IndividualBase] = []
         for i in range(n_parents):
             # note: unclear whether clone() is needed here; using
             # clone() avoids accidentally sharing references across

--- a/cgp/hl_api.py
+++ b/cgp/hl_api.py
@@ -2,13 +2,13 @@ import numpy as np
 from typing import Optional, Callable
 
 from .population import Population
-from .individual import Individual
+from .individual import IndividualBase
 from .ea import MuPlusLambda
 
 
 def evolve(
     pop: Population,
-    objective: Callable[[Individual], Individual],
+    objective: Callable[[IndividualBase], IndividualBase],
     ea: MuPlusLambda,
     max_generations: int,
     min_fitness: float,
@@ -63,6 +63,7 @@ def evolve(
         # progress printing, recording, checking exit condition etc.; needs to
         # be done /after/ new parent population was populated from combined
         # population and /before/ new individuals are created as offsprings
+        assert isinstance(pop.champion.fitness, float)
         if pop.champion.fitness > max_fitness:
             max_fitness = pop.champion.fitness
 

--- a/cgp/local_search/gradient_based.py
+++ b/cgp/local_search/gradient_based.py
@@ -8,15 +8,15 @@ try:
 except ModuleNotFoundError:
     torch_available = False
 
-from typing import Callable, Optional
+from typing import Callable, List, Optional, Union
 
 
-from ..individual import Individual  # noqa: F401
+from ..individual import IndividualBase
 
 
 def gradient_based(
-    individual: Individual,
-    objective: Callable[["torch.nn.Module"], "torch.Tensor"],
+    individual: IndividualBase,
+    objective: Callable[[Union["torch.nn.Module", List["torch.nn.Module"]]], "torch.Tensor"],
     lr: float,
     gradient_steps: int,
     optimizer: Optional["Optimizer"] = None,
@@ -57,20 +57,33 @@ def gradient_based(
 
     f = individual.to_torch()
 
-    if len(list(f.parameters())) > 0:
-        optimizer = optimizer_class(f.parameters(), lr=lr)
+    if isinstance(f, list):
+        params = []
+        for torch_mod in f:
+            params += list(torch_mod.parameters())
+    else:
+        params = list(f.parameters())
+
+    if len(params) > 0:
+        optimizer = optimizer_class(params, lr=lr)
 
         for i in range(gradient_steps):
             loss = objective(f)
             if not torch.isfinite(loss):
                 continue
 
-            f.zero_grad()
+            if isinstance(f, list):
+                for torch_mod in f:
+                    torch_mod.zero_grad()
+            else:
+                f.zero_grad()
+
             loss.backward()
             if clip_value is not np.inf:
-                torch.nn.utils.clip_grad.clip_grad_value_(f.parameters(), clip_value)
+                torch.nn.utils.clip_grad.clip_grad_value_(params, clip_value)
+
             optimizer.step()
 
-            assert all(torch.isfinite(t) for t in f.parameters())
+            assert all(torch.isfinite(t) for t in params)
 
         individual.update_parameters_from_torch_class(f)

--- a/cgp/population.py
+++ b/cgp/population.py
@@ -1,8 +1,9 @@
 import numpy as np
 
-from typing import List
+from typing import List, Union
 
-from .individual import Individual, IndividualMultiGenome
+from .genome import Genome
+from .individual import IndividualBase, IndividualSingleGenome, IndividualMultiGenome
 
 
 class Population:
@@ -11,7 +12,11 @@ class Population:
     """
 
     def __init__(
-        self, n_parents: int, mutation_rate: float, seed: int, genome_params: dict
+        self,
+        n_parents: int,
+        mutation_rate: float,
+        seed: int,
+        genome_params: Union[dict, List[dict]],
     ) -> None:
         """Init function.
 
@@ -38,7 +43,7 @@ class Population:
 
         self._genome_params = genome_params
 
-        self._parents: List[Individual] = []  # list of parent individuals
+        self._parents: List[IndividualBase] = []  # list of parent individuals
 
         # keeps track of the number of generations, increases with
         # every new offspring generation
@@ -48,61 +53,71 @@ class Population:
         self._generate_random_parent_population()
 
     @property
-    def champion(self) -> Individual:
+    def champion(self) -> IndividualBase:
         """Return parent with the highest fitness.
         """
         return max(self._parents, key=lambda ind: ind.fitness)
 
     @property
-    def parents(self) -> List[Individual]:
+    def parents(self) -> List[IndividualBase]:
         return self._parents
 
     @parents.setter
-    def parents(self, new_parents: List[Individual]) -> None:
+    def parents(self, new_parents: List[IndividualBase]) -> None:
         self.generation += 1
         self._parents = new_parents
 
-    def __getitem__(self, idx: int) -> Individual:
+    def __getitem__(self, idx: int) -> IndividualBase:
         return self._parents[idx]
 
     def _generate_random_parent_population(self) -> None:
         self._parents = self._generate_random_individuals(self.n_parents)
         self._label_new_individuals(self._parents)
 
-    def _label_new_individuals(self, individuals: List[Individual]) -> None:
+    def _label_new_individuals(self, individuals: List[IndividualBase]) -> None:
         for ind in individuals:
             ind.idx = self._max_idx + 1
             self._max_idx += 1
 
-    def _generate_random_individuals(self, n: int) -> List[Individual]:
+    def _generate_random_individuals(self, n: int) -> List[IndividualBase]:
         individuals = []
         for i in range(n):
             if isinstance(self._genome_params, dict):
-                individual = Individual(fitness=None, genome=None)
-            elif isinstance(self._genome_params, list) and isinstance(
-                self._genome_params[0], dict
-            ):
-                individual = IndividualMultiGenome(fitness=None, genome=None)
+                genome: Genome = Genome(**self._genome_params)
+                genome.randomize(self.rng)
+                individual_s = IndividualSingleGenome(
+                    fitness=None, genome=genome
+                )  # type: IndividualBase # indicates to mypy that
+                # individual_s is instance of a child class of
+                # IndividualBase
+                individuals.append(individual_s)
             else:
-                raise NotImplementedError()
-            individual.randomize_genome(self._genome_params, self.rng)
-            individuals.append(individual)
-
+                genomes: List[Genome] = [Genome(**gd) for gd in self._genome_params]
+                for g in genomes:
+                    g.randomize(self.rng)
+                individual_m = IndividualMultiGenome(
+                    fitness=None, genome=genomes
+                )  # type: IndividualBase # indicates to mypy that
+                # individual_m is an instance of a child class of
+                # IndividualBase
+                individuals.append(individual_m)
         return individuals
 
-    def crossover(self, breeding_pool: List[Individual], n_offsprings: int) -> List[Individual]:
+    def crossover(
+        self, breeding_pool: List[IndividualBase], n_offsprings: int
+    ) -> List[IndividualBase]:
         """Create an offspring population via crossover.
 
         Parameters
         ----------
-        breeding_pool : List[Individual]
+        breeding_pool : List[IndividualBase]
             List of individuals from which the offspring are created.
         n_offsprings : int
             Number of offspring to be created.
 
         Returns
         ----------
-        List[Individual]
+        List[IndividualBase]
             List of offspring individuals.
         """
         # in principle crossover would rely on a procedure like the
@@ -123,27 +138,34 @@ class Population:
         # Conference on Genetic and Evolutionary Computation-Volume 2,
         # pages 1135–1142. Morgan Kaufmann Publishers Inc.
         assert len(breeding_pool) >= n_offsprings
-        return sorted(breeding_pool, key=lambda x: -x.fitness)[:n_offsprings]
 
-    def mutate(self, offsprings: List[Individual]) -> List[Individual]:
+        def sort_func(ind: IndividualBase) -> float:
+            if isinstance(ind.fitness, float):
+                return ind.fitness
+            else:
+                raise ValueError(f"Individual fitness value is of wrong type {type(ind.fitness)}.")
+
+        # Sort individuals in descending order
+        return sorted(breeding_pool, key=sort_func, reverse=True)[:n_offsprings]
+
+    def mutate(self, offsprings: List[IndividualBase]) -> List[IndividualBase]:
         """Mutate a list of offspring invididuals.
 
         Parameters
         ----------
-        offsprings : List[Individual]
+        offsprings : List[IndividualBase]
             List of offspring individuals to be mutated.
 
         Returns
         ----------
-        List[Individual]
+        List[IndividualBase]
             List of mutated offspring individuals.
         """
-
         for off in offsprings:
             off.mutate(self._mutation_rate, self.rng)
         return offsprings
 
-    def fitness_parents(self) -> List[float]:
+    def fitness_parents(self) -> List[Union[None, float]]:
         """Return fitness for all parents of the population.
 
         Returns
@@ -152,17 +174,3 @@ class Population:
             List of fitness values for all parents.
         """
         return [ind.fitness for ind in self._parents]
-
-    def dna_parents(self) -> List[List[int]]:
-        """Return a list of the DNA of all parents.
-
-        Returns
-        ----------
-        List[List[int]]
-            List of dna of all parents.
-        """
-
-        dnas = np.empty((self.n_parents, self._parents[0].genome._n_genes))
-        for i in range(self.n_parents):
-            dnas[i] = self._parents[i].genome.dna
-        return dnas

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -21,6 +21,11 @@ def genome_params():
 
 
 @fixture
+def genome_params_list(genome_params):
+    return [genome_params]
+
+
+@fixture
 def population_params(mutation_rate, rng_seed):
     return {"n_parents": 5, "mutation_rate": mutation_rate, "seed": rng_seed}
 
@@ -40,6 +45,6 @@ def population_simple_fitness(population_params, genome_params):
     pop = cgp.Population(**population_params, genome_params=genome_params)
 
     for i, parent in enumerate(pop.parents):
-        parent.fitness = i
+        parent.fitness = float(i)
 
     return pop

--- a/test/test_cartesian_graph.py
+++ b/test/test_cartesian_graph.py
@@ -230,9 +230,9 @@ def test_to_numpy():
 
 batch_sizes = [1, 10]
 primitives = (cgp.Mul, cgp.ConstantFloat)
-genomes = [cgp.Genome(1, 1, 2, 2, 1, primitives) for i in range(2)]
+genome = [cgp.Genome(1, 1, 2, 2, 1, primitives) for i in range(2)]
 # Function: f(x) = 1*x
-genomes[0].dna = [
+genome[0].dna = [
     ID_INPUT_NODE,
     ID_NON_CODING_GENE,
     ID_NON_CODING_GENE,
@@ -253,7 +253,7 @@ genomes[0].dna = [
     ID_NON_CODING_GENE,
 ]
 # Function: f(x) = 1
-genomes[1].dna = [
+genome[1].dna = [
     ID_INPUT_NODE,
     ID_NON_CODING_GENE,
     ID_NON_CODING_GENE,
@@ -274,9 +274,9 @@ genomes[1].dna = [
     ID_NON_CODING_GENE,
 ]
 
-genomes += [cgp.Genome(1, 2, 2, 2, 1, primitives) for i in range(2)]
+genome += [cgp.Genome(1, 2, 2, 2, 1, primitives) for i in range(2)]
 # Function: f(x) = (1*x, 1*1)
-genomes[2].dna = [
+genome[2].dna = [
     ID_INPUT_NODE,
     ID_NON_CODING_GENE,
     ID_NON_CODING_GENE,
@@ -300,7 +300,7 @@ genomes[2].dna = [
     ID_NON_CODING_GENE,
 ]
 # Function: f(x) = (1, x*x)
-genomes[3].dna = [
+genome[3].dna = [
     ID_INPUT_NODE,
     ID_NON_CODING_GENE,
     ID_NON_CODING_GENE,
@@ -325,7 +325,7 @@ genomes[3].dna = [
 ]
 
 
-@pytest.mark.parametrize("genome, batch_size", itertools.product(genomes, batch_sizes))
+@pytest.mark.parametrize("genome, batch_size", itertools.product(genome, batch_sizes))
 def test_compile_numpy_output_shape(genome, batch_size):
 
     c = cgp.CartesianGraph(genome).to_numpy()
@@ -334,7 +334,7 @@ def test_compile_numpy_output_shape(genome, batch_size):
     assert y.shape == (batch_size, genome._n_outputs)
 
 
-@pytest.mark.parametrize("genome, batch_size", itertools.product(genomes, batch_sizes))
+@pytest.mark.parametrize("genome, batch_size", itertools.product(genome, batch_sizes))
 def test_compile_torch_output_shape(genome, batch_size):
     torch = pytest.importorskip("torch")
 

--- a/test/test_ea_mu_plus_lambda.py
+++ b/test/test_ea_mu_plus_lambda.py
@@ -7,12 +7,12 @@ import cgp
 
 def test_objective_with_label(population_params, genome_params):
     def objective_without_label(individual):
-        individual.fitness = -2
+        individual.fitness = -2.0
         return individual
 
     def objective_with_label(individual, label):
         assert label == "test"
-        individual.fitness = -1
+        individual.fitness = -1.0
         return individual
 
     pop = cgp.Population(**population_params, genome_params=genome_params)

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -295,9 +295,9 @@ def test_catch_invalid_allele_in_inactive_region():
     genome.dna = [ID_INPUT_NODE, ID_NON_CODING_GENE, 0, 0, ID_OUTPUT_NODE, 1]
 
 
-def test_individuals_have_different_genomes(population_params, genome_params, ea_params):
+def test_individuals_have_different_genome(population_params, genome_params, ea_params):
     def objective(ind):
-        ind.fitness = ind.idx
+        ind.fitness = float(ind.idx)
         return ind
 
     pop = cgp.Population(**population_params, genome_params=genome_params)
@@ -310,7 +310,6 @@ def test_individuals_have_different_genomes(population_params, genome_params, ea
     ea.step(pop, objective)
 
     for i, parent_i in enumerate(pop._parents):
-
         for j, parent_j in enumerate(pop._parents):
             if i != j:
                 assert parent_i is not parent_j

--- a/test/test_hl_api.py
+++ b/test/test_hl_api.py
@@ -65,7 +65,6 @@ def test_parallel_population(population_params, genome_params, ea_params):
         fitness_per_n_processes.append(
             _test_population(population_params, genome_params, ea_params)
         )
-
     assert fitness_per_n_processes[0] == pytest.approx(fitness_per_n_processes[1])
     assert fitness_per_n_processes[0] == pytest.approx(fitness_per_n_processes[2])
 
@@ -94,9 +93,8 @@ def test_evolve_two_expressions(population_params, ea_params):
             x0 = np.random.uniform(size=1)
             x1 = np.random.uniform(size=2)
 
-            loss += (f0(x0) - y0(x0)) ** 2
-            loss += (f1(x1) - y1(x1)) ** 2
-
+            loss += float((f0(x0) - y0(x0)) ** 2)
+            loss += float((f1(x1) - y1(x1)) ** 2)
         individual.fitness = -loss
 
         return individual

--- a/test/test_individual.py
+++ b/test/test_individual.py
@@ -3,7 +3,7 @@ import pickle
 import pytest
 
 import cgp
-from cgp.individual import Individual
+from cgp.individual import IndividualSingleGenome
 from cgp.genome import ID_INPUT_NODE, ID_OUTPUT_NODE, ID_NON_CODING_GENE
 
 
@@ -11,7 +11,7 @@ def test_pickle_individual():
 
     primitives = (cgp.Add,)
     genome = cgp.Genome(1, 1, 1, 1, 1, primitives)
-    individual = Individual(None, genome)
+    individual = IndividualSingleGenome(None, genome)
 
     with open("individual.pkl", "wb") as f:
         pickle.dump(individual, f)
@@ -36,7 +36,7 @@ def test_individual_with_parameter_python():
         2,
         ID_NON_CODING_GENE,
     ]
-    individual = Individual(None, genome)
+    individual = IndividualSingleGenome(None, genome)
 
     c = 1.0
     x = [3.0]
@@ -74,7 +74,7 @@ def test_individual_with_parameter_torch():
         2,
         ID_NON_CODING_GENE,
     ]
-    individual = Individual(None, genome)
+    individual = IndividualSingleGenome(None, genome)
 
     c = 1.0
     x = torch.empty(2, 1).normal_()
@@ -114,7 +114,7 @@ def test_individual_with_parameter_sympy():
         2,
         ID_NON_CODING_GENE,
     ]
-    individual = Individual(None, genome)
+    individual = IndividualSingleGenome(None, genome)
 
     c = 1.0
     x = [3.0]
@@ -158,7 +158,7 @@ def test_to_and_from_torch_plus_backprop():
         3,
         ID_NON_CODING_GENE,
     ]
-    individual = Individual(None, genome)
+    individual = IndividualSingleGenome(None, genome)
 
     def f_target(x):
         return math.pi * x
@@ -217,7 +217,7 @@ def test_update_parameters_from_torch_class_resets_fitness():
         ID_NON_CODING_GENE,
     ]
     fitness = 1.0
-    individual = Individual(fitness, genome)
+    individual = IndividualSingleGenome(fitness, genome)
 
     f = individual.to_torch()
     f._p1.data[0] = math.pi
@@ -251,7 +251,7 @@ def test_update_parameters_from_torch_class_does_not_reset_fitness_for_unused_pa
         ID_NON_CODING_GENE,
     ]
     fitness = 1.0
-    individual = Individual(fitness, genome)
+    individual = IndividualSingleGenome(fitness, genome)
 
     f = individual.to_torch()
 

--- a/test/test_local_search.py
+++ b/test/test_local_search.py
@@ -11,7 +11,7 @@ def test_gradient_based_step_towards_maximum():
     genome = cgp.Genome(1, 1, 1, 1, 1, primitives)
     # f(x) = c
     genome.dna = [ID_INPUT_NODE, ID_NON_CODING_GENE, 0, 0, ID_OUTPUT_NODE, 1]
-    ind = cgp.individual.Individual(None, genome)
+    ind = cgp.individual.IndividualSingleGenome(None, genome)
 
     def objective(f):
         x_dummy = torch.zeros((1, 1), dtype=torch.double)  # not used

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -94,10 +94,7 @@ def test_history_recording(population_params, genome_params, ea_params):
     pop = cgp.Population(**population_params, genome_params=genome_params)
     ea = cgp.ea.MuPlusLambda(**ea_params)
 
-    evolve_params = {
-        "max_generations": 2,
-        "min_fitness": 1.0,
-    }
+    evolve_params = {"max_generations": 2, "min_fitness": 1.0}
 
     history = {}
     history["fitness"] = np.empty(
@@ -111,9 +108,7 @@ def test_history_recording(population_params, genome_params, ea_params):
         history["fitness_champion"][pop.generation] = pop.champion.fitness
         history["champion"].append(pop.champion)
 
-    cgp.evolve(
-        pop, objective_history_recording, ea, **evolve_params, callback=recording_callback,
-    )
+    cgp.evolve(pop, objective_history_recording, ea, **evolve_params, callback=recording_callback)
 
     assert np.all(history["fitness"] == pytest.approx(1.0))
     assert np.all(history["fitness_champion"] == pytest.approx(1.0))


### PR DESCRIPTION
This PR adds type hints to the `Individual` and `IndividualMultiGenome` classes and fixes the detected issues:

1. `Individual` and `IndividualMultiGenome` class
The relation between the two classes was not good: Having IndividualMultiGenome inherit from Individual causes problems. For instance, the self.genome member is a list of Genome instances in the former, but since it is initialized in the latter as a Genome instance, this does not make much sense. We could refrain from calling the super().__init__() function but then the inheritance does not make any sense. 

*Solution*: As discussed below, I removed the `IndividualMultiGenome` class and make the `self.genome` member of `Individual` a list. This triggered some changes in the `Population` class and the local search algorithms which now needs a list of `genome_params` and in the tests. As a side remark: Some functionality would not have worked for the multi genome version, e.g. the local search. This PR removes this problem.

2. The `Individual` class could be initialized with `genome=None` which is dangerous because all its methods rely on a genome being defined. I removed this option therefore and adapted the code in the `Population` class which had used this feature. 

3. `Individual.fitness` can be `None`
This is dangerous because some of the operations on the fitness relied on the fitness being a float without explicitly checking or catching exceptions. I remedied this in this PR.
 