### PR TITLE
Move all shared functionality from IndividualSingle/MultiGenome to base class

### DIFF
--- a/cgp/individual.py
+++ b/cgp/individual.py
@@ -20,98 +20,54 @@ from .genome import Genome
 from .cartesian_graph import CartesianGraph
 
 
-def mutate_genome(genome: Genome, mutation_rate: float, rng: np.random.RandomState) -> bool:
-    """Mutate a given genome.
-
-    Parameters
-    ----------
-    mutation_rate : float
-        Proportion of genes to be mutated, between 0 and 1.
-    rng : numpy.RandomState
-        Random number generator instance.
-
-    Returns
-    -------
-    bool
-        Whether all mutations were silent.
-    """
-    n_mutations = int(mutation_rate * len(genome.dna))
-    assert n_mutations > 0
-
-    graph = CartesianGraph(genome)
-    active_regions = graph.determine_active_regions()
-    only_silent_mutations = genome.mutate(n_mutations, active_regions, rng)
-
-    return only_silent_mutations
-
-
 class IndividualBase:
     """Base class for all individuals.
     """
 
-    def __init__(self, fitness: Union[float, None], genome: Union[Genome, List[Genome]]) -> None:
+    def __init__(self, fitness: Union[float, None]) -> None:
         """Init function.
 
         fitness : float
             Fitness of the individual.
         """
-        self.fitness = fitness
-        self.genome: Union[Genome, List[Genome]]
+        self.fitness : Union[float, None] = fitness
         self.idx: int
 
-    def __repr__(self):
-        return f"Individual(idx={self.idx}, fitness={self.fitness}, genome={self.genome}))"
-
-    def clone(self) -> "IndividualBase":
-        """Clone the individual.
-
-        Returns
-        -------
-        Individual
-        """
-        return type(self)(self.fitness, self.genome)
-
-    def crossover(self, other_parent: "IndividualBase", rng: np.random.RandomState) -> None:
-        """Create a new individual by cross over with another individual.
+    @staticmethod
+    def _mutate_genome(genome: Genome, mutation_rate: float, rng: np.random.RandomState) -> bool:
+        """Mutate a given genome.
 
         Parameters
         ----------
-        other_parent : Individual
-            Other individual to perform crossover with.
-        rng : numpy.random.RandomState
-            Random number generator instance to use for crossover.
-
-        Returns
-        -------
-        Individual
-        """
-        raise NotImplementedError("crossover currently not supported")
-
-    def mutate(self, mutation_rate: float, rng: np.random.RandomState) -> None:
-        """Mutate the individual in place.
-
-        Parameters
-        ----------
+        genome : Genome
+            Genome to be mutated.
         mutation_rate : float
             Proportion of genes to be mutated, between 0 and 1.
         rng : numpy.RandomState
-            Random number generator instance to use for crossover.
+            Random number generator instance.
 
         Returns
         -------
-        None
+        bool
+            Whether all mutations were silent.
         """
-        pass
+        n_mutations = int(mutation_rate * len(genome.dna))
+        assert n_mutations > 0
 
-    def randomize_genome(self, rng: np.random.RandomState) -> None:
+        graph = CartesianGraph(genome)
+        active_regions = graph.determine_active_regions()
+        only_silent_mutations = genome.mutate(n_mutations, active_regions, rng)
+
+        return only_silent_mutations
+
+    @staticmethod
+    def _randomize_genome(genome: Genome, rng: np.random.RandomState) -> None:
         """Randomize the individual's genome.
 
         Parameters
         ----------
-        genome_params : dict
-            Parameter dictionary for the new randomized genome.
-            Needs to contain: n_inputs, n_outputs, n_columns, n_rows,
-            levels_back, primitives.
+        genome : Genome
+            Genome to be randomized.
         rng : numpy.RandomState
             Random number generator instance to use for crossover.
 
@@ -119,56 +75,29 @@ class IndividualBase:
         -------
         None
         """
-        pass
+        genome.randomize(rng)
 
-    def to_func(
-        self
-    ) -> Union[Callable[[List[float]], List[float]], List[Callable[[List[float]], List[float]]]]:
-        """Return the expression represented by the individual as Callable.
+    @staticmethod
+    def _to_func(genome: Genome) -> Callable[[List[float]], List[float]]:
+        return CartesianGraph(genome).to_func()
 
-        Returns
-        ----------
-        Callable[[List[float]], List[float]]
-        """
-        pass
+    @staticmethod
+    def _to_numpy(genome: Genome) -> Callable[[np.ndarray], np.ndarray]:
+        return CartesianGraph(genome).to_numpy()
 
-    def to_numpy(
-        self
-    ) -> Union[Callable[[np.ndarray], np.ndarray], List[Callable[[np.ndarray], np.ndarray]]]:
-        """Return the expression represented by the individual as
-        NumPy-compatible Callable.
+    @staticmethod
+    def _to_torch(genome: Genome) -> "torch.nn.Module":
+        return CartesianGraph(genome).to_torch()
 
-        Returns
-        -------
-        Callable[[np.ndarray], np.ndarray]:
-        """
-        pass
+    @staticmethod
+    def _to_sympy(genome: Genome, simplify) -> "sympy_expr.Expr":
+        return CartesianGraph(genome).to_sympy(simplify)
 
-    def to_torch(self) -> Union["torch.nn.Module", List["torch.nn.Module"]]:
-        """Return the expression represented by the individual as Torch class.
-
-        Returns
-        -------
-        torch.nn.Module
-        """
-        pass
-
-    def to_sympy(self, simplify: bool = True) -> Union["sympy_expr.Expr", List["sympy_expr.Expr"]]:
-        """Return the expression represented by the individual as SymPy
-        expression.
-
-        Returns
-        -------
-        List[sympy_expr.Expr]:
-        """
-        pass
-
-    def update_parameters_from_torch_class(
-        self, torch_cls: Union["torch.nn.Module", List["torch.nn.Module"]]
-    ) -> None:
+    @staticmethod
+    def _update_parameters_from_torch_class(genome: Genome, torch_cls: "torch.nn.Module") -> bool:
         """Update parameters of the individual from a torch class.
         """
-        pass
+        return genome.update_parameters_from_torch_class(torch_cls)
 
 
 class IndividualSingleGenome(IndividualBase):
@@ -183,31 +112,37 @@ class IndividualSingleGenome(IndividualBase):
         genome: Genome instance
             Genome of the individual.
         """
-        super().__init__(fitness, genome)
+        super().__init__(fitness)
         self.genome: Genome = genome
 
+    def __repr__(self):
+        return f"Individual(idx={self.idx}, fitness={self.fitness}, genome={self.genome}))"
+
+    def clone(self) -> "IndividualSingleGenome":
+        return IndividualSingleGenome(self.fitness, self.genome.clone())
+
     def mutate(self, mutation_rate: float, rng: np.random.RandomState) -> None:
-        only_silent_mutations = mutate_genome(self.genome, mutation_rate, rng)
+        only_silent_mutations = self._mutate_genome(self.genome, mutation_rate, rng)
         if not only_silent_mutations:
             self.fitness = None
 
     def randomize_genome(self, rng: np.random.RandomState) -> None:
-        self.genome.randomize(rng)
+        self._randomize_genome(self.genome, rng)
 
     def to_func(self) -> Callable[[List[float]], List[float]]:
-        return CartesianGraph(self.genome).to_func()
+        return self._to_func(self.genome)
 
     def to_numpy(self) -> Callable[[np.ndarray], np.ndarray]:
-        return CartesianGraph(self.genome).to_numpy()
+        return self._to_numpy(self.genome)
 
     def to_torch(self) -> "torch.nn.Module":
-        return CartesianGraph(self.genome).to_torch()
+        return self._to_torch(self.genome)
 
     def to_sympy(self, simplify: bool = True) -> "sympy_expr.Expr":
-        return CartesianGraph(self.genome).to_sympy(simplify)
+        return self._to_sympy(self.genome, simplify)
 
     def update_parameters_from_torch_class(self, torch_cls: "torch.nn.Module") -> None:
-        any_parameter_updated = self.genome.update_parameters_from_torch_class(torch_cls)
+        any_parameter_updated = self._update_parameters_from_torch_class(self.genome, torch_cls)
         if any_parameter_updated:
             self.fitness = None
 
@@ -216,7 +151,7 @@ class IndividualMultiGenome(IndividualBase):
     """An individual with multiple genomes each representing a particular computational graph.
     """
 
-    def __init__(self, fitness: Union[float, None], genome: List[Genome]) -> None:
+    def __init__(self, fitness: Union[float, None], genomes: List[Genome]) -> None:
         """Init function.
 
         fitness : float
@@ -224,38 +159,37 @@ class IndividualMultiGenome(IndividualBase):
         genome: Genome instance
             Genome of the individual.
         """
-        super().__init__(fitness, genome)
+        super().__init__(fitness)
+        self.genomes: List[Genome] = genomes
 
-        self.genome: List[Genome] = genome
+    def clone(self) -> "IndividualMultiGenome":
+        return IndividualMultiGenome(self.fitness, [g.clone() for g in self.genomes])
 
     def mutate(self, mutation_rate: float, rng: np.random.RandomState) -> None:
-        for g in self.genome:
-            only_silent_mutations = mutate_genome(g, mutation_rate, rng)
+        for g in self.genomes:
+            only_silent_mutations = self._mutate_genome(g, mutation_rate, rng)
             if not only_silent_mutations:
                 self.fitness = None
 
     def randomize_genome(self, rng: np.random.RandomState) -> None:
-        for g in self.genome:
-            g.randomize(rng)
+        for g in self.genomes:
+            self._randomize_genome(g, rng)
 
     def to_func(self) -> List[Callable[[List[float]], List[float]]]:
-        if len(self.genome) == 1:
-            return CartesianGraph(self.genome[0]).to_func()
-        else:
-            return [CartesianGraph(g).to_func() for g in self.genome]
+        return [self._to_func(g) for g in self.genomes]
 
     def to_numpy(self) -> List[Callable[[np.ndarray], np.ndarray]]:
-        return [CartesianGraph(g).to_numpy() for g in self.genome]
+        return [self._to_numpy(g) for g in self.genomes]
 
     def to_torch(self) -> List["torch.nn.Module"]:
-        return [CartesianGraph(g).to_torch() for g in self.genome]
+        return [self._to_torch(g) for g in self.genomes]
 
     def to_sympy(self, simplify: bool = True) -> List["sympy_expr.Expr"]:
-        return [CartesianGraph(g).to_sympy(simplify) for g in self.genome]
+        return [self._to_sympy(g, simplify) for g in self.genomes]
 
     def update_parameters_from_torch_class(self, torch_cls: List["torch.nn.Module"]) -> None:
         any_parameter_updated = any(
-            [g.update_parameters_from_torch_class(tcls) for g, tcls in zip(self.genome, torch_cls)]
+            [self._update_parameters_from_torch_class(g, tcls) for g, tcls in zip(self.genomes, torch_cls)]
         )
 
         if any_parameter_updated:


### PR DESCRIPTION
as discussed on slack, this moves all functionality from the derived classes into the base class where static methods which operate on `Genome` are defined. might seem to be too many indirections, e.g., `to_func -> _to_func -> to_func` but this makes the derived classes trivial to understand as they only call the static methods on each of their `Genome` members. note that here `__repr__` is missing. `crossover` was intentionally deleted to remove dead code.