### PR TITLE
Fix mypy issues by defining methods in parent class without typing

### DIFF
--- a/cgp/individual.py
+++ b/cgp/individual.py
@@ -34,6 +34,30 @@ class IndividualBase:
         self.fitness : Union[float, None] = fitness
         self.idx: int
 
+    def clone(self):
+        raise NotImplementedError()
+
+    def mutate(self, mutation_rate, rng):
+        raise NotImplementedError()
+
+    def randomize_genome(self, rng):
+        raise NotImplementedError()
+
+    def to_func(self):
+        raise NotImplementedError()
+
+    def to_numpy(self):
+        raise NotImplementedError()
+
+    def to_torch(self):
+        raise NotImplementedError()
+
+    def to_sympy(self, simplify):
+        raise NotImplementedError()
+
+    def update_parameters_from_torch_class(self, torch_cls):
+        raise NotImplementedError()
+
     @staticmethod
     def _mutate_genome(genome: Genome, mutation_rate: float, rng: np.random.RandomState) -> bool:
         """Mutate a given genome.

--- a/cgp/population.py
+++ b/cgp/population.py
@@ -94,7 +94,7 @@ class Population:
                 for gen in genomes:
                     gen.randomize(self.rng)
                 individual_m = IndividualMultiGenome(
-                    fitness=None, genome=genomes
+                    fitness=None, genomes=genomes
                 )  # type: IndividualBase
                 individuals.append(individual_m)
         return individuals
@@ -169,23 +169,3 @@ class Population:
             List of fitness values for all parents.
         """
         return [ind.fitness for ind in self._parents]
-
-    def dna_parents(self) -> Union[List[List[int]], List[List[List[int]]]]:
-        """Return a list of the DNA of all parents.
-
-        Returns
-        ----------
-        List[List[List[int]]]
-            List of dna of all parents.
-        """
-
-        if isinstance(self._genome_params, dict):
-            dnas: List[List[int]] = []
-        elif isinstance(self._genome_params, List[dict]):
-            dnas: List[List[List[int]]] = []
-        for parent in self.parents:
-            if isinstance(parent, IndividualSingleGenome):
-                dnas.append(parent.genome.dna)
-            elif isinstance(parent, IndividualSingleGenome):
-                dnas.append([gen.dna for gen in parent.genome])
-        return dnas

--- a/test/test_hl_api.py
+++ b/test/test_hl_api.py
@@ -84,8 +84,8 @@ def test_evolve_two_expressions(population_params, ea_params):
         def f1(x):
             return (x[0] * x[1]) - x[1]
 
-        y0 = cgp.CartesianGraph(individual.genome[0]).to_func()
-        y1 = cgp.CartesianGraph(individual.genome[1]).to_func()
+        y0 = cgp.CartesianGraph(individual.genomes[0]).to_func()
+        y1 = cgp.CartesianGraph(individual.genomes[1]).to_func()
 
         loss = 0
         for _ in range(100):

--- a/test/test_population.py
+++ b/test/test_population.py
@@ -77,11 +77,11 @@ def test_fitness_parents(population_params, genome_params_list):
     assert np.all(pop.fitness_parents() == pytest.approx(fitness_values))
 
 
-def test_pop_uses_own_rng(population_params, genome_params_list, rng_seed):
+def test_pop_uses_own_rng(population_params, genome_params, rng_seed):
     """Test independence of Population on global numpy rng.
     """
 
-    pop = cgp.Population(**population_params, genome_params=genome_params_list)
+    pop = cgp.Population(**population_params, genome_params=genome_params)
 
     np.random.seed(rng_seed)
 
@@ -96,4 +96,4 @@ def test_pop_uses_own_rng(population_params, genome_params_list, rng_seed):
     # since Population does not depend on global rng seed, we
     # expect different individuals in the two populations
     for p_0, p_1 in zip(parents_0, parents_1):
-        assert all([g0.dna != g1.dna for g0, g1 in zip(p_0.genome, p_1.genome)])
+        assert p_0.genome.dna != p_1.genome.dna


### PR DESCRIPTION
apparently one can drop the annotations in the parent class, functions only need to have the same signature, not typing. this resolves the mypy issues. i've also removed a function that i think we never used but which caused annoying mypy problems. also fixed the tests.