### PR TITLE
Avoid catching of SymPy expression

### DIFF
--- a/cgp/cartesian_graph.py
+++ b/cgp/cartesian_graph.py
@@ -4,7 +4,7 @@ import re
 
 try:
     import sympy
-    from sympy.core import expr as sympy_expr
+    from sympy.core import expr as sympy_expr  # noqa: F401
 
     sympy_available = True
 except ModuleNotFoundError:
@@ -377,20 +377,6 @@ class _C(torch.nn.Module):
         if not sympy_available:
             raise ModuleNotFoundError("No module named 'sympy' (extra requirement)")
 
-        def _validate_sympy_expr(expr: sympy_expr.Expr) -> sympy_expr.Expr:
-            """Helper function that raises an exception upon encountering a SymPy
-            expression that can not be evaluated.
-
-            """
-
-            class InvalidSympyExpression(Exception):
-                pass
-
-            if "zoo" in str(expr) or "nan" in str(expr):
-                raise InvalidSympyExpression(str(expr))
-
-            return expr
-
         self._format_output_str_of_all_nodes()
 
         sympy_exprs = []
@@ -414,5 +400,5 @@ class _C(torch.nn.Module):
             return sympy_exprs
         else:  # simplify expression if desired
             for i, expr in enumerate(sympy_exprs):
-                sympy_exprs[i] = _validate_sympy_expr(expr.simplify())
+                sympy_exprs[i] = expr.simplify()
             return sympy_exprs

--- a/test/test_cartesian_graph.py
+++ b/test/test_cartesian_graph.py
@@ -383,7 +383,7 @@ def test_to_sympy():
         )
 
 
-def test_catch_invalid_sympy_expr():
+def test_allow_sympy_expr_with_infinities():
     pytest.importorskip("sympy")
 
     primitives = (cgp.Sub, cgp.Div)
@@ -406,8 +406,9 @@ def test_catch_invalid_sympy_expr():
     ]
     graph = cgp.CartesianGraph(genome)
 
-    with pytest.raises(Exception):
-        graph.to_sympy(simplify=True)
+    expr = graph.to_sympy(simplify=True)[0]
+    # complex infinity should appear in expression
+    assert "zoo" in str(expr)
 
 
 def test_allow_powers_of_x_0():


### PR DESCRIPTION
These kind of problems should not be caught but propagated to the user who will know how to deal with them appropriately. This specific case is even worse: since the `InvalidSympyExpression` is only defined locally in `_validate_sympy_expr`, we can't even catch that specific expression outside on the user level, forcing us to use a catch all.