### PR TITLE
Fix bug in IndividualMultiGenome and add test

### DIFF
--- a/cgp/individual.py
+++ b/cgp/individual.py
@@ -211,9 +211,10 @@ class IndividualMultiGenome(IndividualBase):
 
     def update_parameters_from_torch_class(self, torch_cls: List["torch.nn.Module"]) -> None:
         any_parameter_updated = any(
-            self._update_parameters_from_torch_class(g, tcls)
-            for g, tcls in zip(self.genome, torch_cls)
+            [
+                self._update_parameters_from_torch_class(g, tcls)
+                for g, tcls in zip(self.genome, torch_cls)
+            ]
         )
-
         if any_parameter_updated:
             self.fitness = None

--- a/test/test_local_search.py
+++ b/test/test_local_search.py
@@ -32,3 +32,43 @@ def test_gradient_based_step_towards_maximum():
     ind.genome.parameter_names_to_values["<p1>"] = 1.0
     cgp.local_search.gradient_based(ind, objective, 0.05, 1)
     assert ind.genome.parameter_names_to_values["<p1>"] == pytest.approx(1.0)
+
+
+def test_gradient_based_step_towards_maximum_multi_genome():
+    torch = pytest.importorskip("torch")
+
+    primitives = (cgp.Parameter,)
+    genome = cgp.Genome(1, 1, 1, 1, 1, primitives)
+    # f(x) = c
+    genome.dna = [ID_INPUT_NODE, ID_NON_CODING_GENE, 0, 0, ID_OUTPUT_NODE, 1]
+    genome2 = genome.clone()
+    ind = cgp.individual.IndividualMultiGenome(None, [genome, genome2])
+
+    def objective(f):
+        x_dummy = torch.zeros((1, 1), dtype=torch.double)  # not used
+        target_value = torch.ones((1, 1), dtype=torch.double)
+        loss = torch.nn.MSELoss()(f[0](x_dummy), target_value) + 2 * torch.nn.MSELoss()(
+            f[1](x_dummy), target_value
+        )
+        return loss
+
+    # test increase parameter value if too small
+    ind.genome[0].parameter_names_to_values["<p1>"] = 0.9
+    ind.genome[1].parameter_names_to_values["<p1>"] = 0.9
+    cgp.local_search.gradient_based(ind, objective, 0.05, 1)
+    assert ind.genome[0].parameter_names_to_values["<p1>"] == pytest.approx(0.91)
+    assert ind.genome[1].parameter_names_to_values["<p1>"] == pytest.approx(0.92)
+
+    # test decrease parameter value if too large
+    ind.genome[0].parameter_names_to_values["<p1>"] = 1.1
+    ind.genome[1].parameter_names_to_values["<p1>"] = 1.1
+    cgp.local_search.gradient_based(ind, objective, 0.05, 1)
+    assert ind.genome[0].parameter_names_to_values["<p1>"] == pytest.approx(1.09)
+    assert ind.genome[1].parameter_names_to_values["<p1>"] == pytest.approx(1.08)
+
+    # test no change of parameter value if at optimum
+    ind.genome[0].parameter_names_to_values["<p1>"] = 1.0
+    ind.genome[1].parameter_names_to_values["<p1>"] = 1.0
+    cgp.local_search.gradient_based(ind, objective, 0.05, 1)
+    assert ind.genome[0].parameter_names_to_values["<p1>"] == pytest.approx(1.0)
+    assert ind.genome[1].parameter_names_to_values["<p1>"] == pytest.approx(1.0)


### PR DESCRIPTION
This PR adds a test for local search with `IndividualMultiGenome` and fixes but in the `update_parameters_from_torch_class` function.

The bug was tricky: We called `any()` on a generator. However, it turns out that if do that, then the iteration stops once the condition inside `any()` has been evaluated to `True` once. That makes sense since `any()` will return `True` if any of the conditions is `True`, i.e., there is no point in continuing after finding one evaluation to `True`. 
Obviously, this is not what we want here, because all the genomes should update their parameters. Thus, I turned the generator into a list comprehension to make sure that all genomes are updated.

The test extends the test for `IndividualSingleGenome` by using two genomes and defining the loss function such that the second genome is counted with a weighting factor of twice.

Fixes #127 .
