### PR TITLE
Add examples to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,10 @@ script:
   - flake8 --config=.flake8 .
   - mypy cgp
   - pytest --cov=cgp
+  - if [ "$DEP" = "[all]" -a $TRAVIS_PYTHON_VERSION = 3.8 ]; then
+       python examples/example_evo_regression.py || exit 1 ;
+       python examples/example_differential_evo_regression.py || exit 1;
+       python examples/example_caching.py || exit 1;
+    fi
 after_success:
   - coveralls


### PR DESCRIPTION
This PR adds the examples to the CI. Note that the examples require the extra requirements, therefore we cannot run the examples in all jobs.

Discussion point: Perhaps it's sufficient to run the examples in one Python version?

Fixes #122 