### PR TITLE
Enh/custom parameter init

### DIFF
--- a/cgp/cartesian_graph.py
+++ b/cgp/cartesian_graph.py
@@ -1,4 +1,5 @@
 import collections
+import copy
 import numpy as np  # noqa: F401
 import re
 
@@ -17,7 +18,7 @@ try:
 except ModuleNotFoundError:
     torch_available = False
 
-from typing import Callable, DefaultDict, Dict, List, Optional, Set, TYPE_CHECKING
+from typing import Callable, Dict, List, Optional, Set, TYPE_CHECKING
 
 from .node import Node, InputNode, OutputNode, Parameter
 
@@ -43,7 +44,7 @@ class CartesianGraph:
         self._n_columns: int
         self._n_rows: int
         self._nodes: List
-        self._parameter_names_to_values: DefaultDict
+        self._parameter_names_to_values: Dict[str, float]
 
         self.parse_genome(genome)
 
@@ -105,11 +106,7 @@ class CartesianGraph:
         self._n_outputs = genome._n_outputs
         self._n_columns = genome._n_columns
         self._n_rows = genome._n_rows
-
-        # WARNING: creating a reference, not a copy here is essential;
-        # accessing missing elements in this DefaultDict during graph
-        # construction needs to construct keys with default values
-        self._parameter_names_to_values = genome.parameter_names_to_values
+        self._parameter_names_to_values = copy.deepcopy(genome._parameter_names_to_values)
 
         self._nodes = []
 

--- a/cgp/node.py
+++ b/cgp/node.py
@@ -285,6 +285,10 @@ class Parameter(Node):
             f"self._p{self._idx} = torch.nn.Parameter(torch.DoubleTensor([<p{self._idx}>]))\n"
         )
 
+    @staticmethod
+    def initial_value() -> float:
+        return 1.0
+
 
 class InputNode(Node):
     """Node representing a generic input node.

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -370,35 +370,26 @@ def test_mutate_hidden_region(rng_seed):
     active_regions = cgp.CartesianGraph(genome).determine_active_regions()
 
     # mutating any gene in inactive region returns True
-    genome.dna = list(dna)
-    assert genome._mutate_hidden_region(3, active_regions, rng) is True
-    genome.dna = list(dna)
-    assert genome._mutate_hidden_region(4, active_regions, rng) is True
-    genome.dna = list(dna)
-    assert genome._mutate_hidden_region(5, active_regions, rng) is True
+    assert genome._mutate_hidden_region(list(dna), 3, active_regions, rng) is True
+    assert genome._mutate_hidden_region(list(dna), 4, active_regions, rng) is True
+    assert genome._mutate_hidden_region(list(dna), 5, active_regions, rng) is True
 
     # mutating function gene in active region returns False
-    genome.dna = list(dna)
-    assert genome._mutate_hidden_region(6, active_regions, rng) is False
+    assert genome._mutate_hidden_region(list(dna), 6, active_regions, rng) is False
     # mutating inactive genes in active region returns True
-    genome.dna = list(dna)
-    assert genome._mutate_hidden_region(7, active_regions, rng) is True
-    genome.dna = list(dna)
-    assert genome._mutate_hidden_region(8, active_regions, rng) is True
+    assert genome._mutate_hidden_region(list(dna), 7, active_regions, rng) is True
+    assert genome._mutate_hidden_region(list(dna), 8, active_regions, rng) is True
 
     # mutating any gene in active region without silent genes returns False
-    genome.dna = list(dna)
-    assert genome._mutate_hidden_region(9, active_regions, rng) is False
-    genome.dna = list(dna)
-    assert genome._mutate_hidden_region(10, active_regions, rng) is False
-    genome.dna = list(dna)
-    assert genome._mutate_hidden_region(11, active_regions, rng) is False
+    assert genome._mutate_hidden_region(list(dna), 9, active_regions, rng) is False
+    assert genome._mutate_hidden_region(list(dna), 10, active_regions, rng) is False
+    assert genome._mutate_hidden_region(list(dna), 11, active_regions, rng) is False
 
 
 def test_mutate_output_region(rng_seed):
     rng = np.random.RandomState(rng_seed)
     genome = cgp.Genome(1, 1, 2, 1, None, (cgp.Add,))
-    genome.dna = [
+    dna = [
         ID_INPUT_NODE,
         ID_NON_CODING_GENE,
         ID_NON_CODING_GENE,
@@ -413,6 +404,6 @@ def test_mutate_output_region(rng_seed):
         ID_NON_CODING_GENE,
     ]
 
-    assert genome._mutate_output_region(9, rng) is False
-    assert genome._mutate_output_region(10, rng) is True
-    assert genome._mutate_output_region(11, rng) is False
+    assert genome._mutate_output_region(list(dna), 9, rng) is False
+    assert genome._mutate_output_region(list(dna), 10, rng) is True
+    assert genome._mutate_output_region(list(dna), 11, rng) is False

--- a/test/test_individual.py
+++ b/test/test_individual.py
@@ -47,7 +47,7 @@ def test_individual_with_parameter_python():
     assert y[0] == pytest.approx(x[0] + c)
 
     c = 2.0
-    individual.genome.parameter_names_to_values["<p1>"] = c
+    individual.genome._parameter_names_to_values["<p1>"] = c
 
     f = individual.to_func()
     y = f(x)
@@ -86,7 +86,7 @@ def test_individual_with_parameter_torch():
     assert y[1, 0].item() == pytest.approx(x[1, 0].item() + c)
 
     c = 2.0
-    individual.genome.parameter_names_to_values["<p1>"] = c
+    individual.genome._parameter_names_to_values["<p1>"] = c
 
     f = individual.to_torch()
     y = f(x)
@@ -125,7 +125,7 @@ def test_individual_with_parameter_sympy():
     assert y == pytest.approx(x[0] + c)
 
     c = 2.0
-    individual.genome.parameter_names_to_values["<p1>"] = c
+    individual.genome._parameter_names_to_values["<p1>"] = c
 
     f = individual.to_sympy()[0]
     y = f.subs("x_0", x[0]).evalf()

--- a/test/test_local_search.py
+++ b/test/test_local_search.py
@@ -19,19 +19,19 @@ def test_gradient_based_step_towards_maximum():
         return torch.nn.MSELoss()(f(x_dummy), target_value)
 
     # test increase parameter value if too small
-    ind.genome.parameter_names_to_values["<p1>"] = 0.9
+    ind.genome._parameter_names_to_values["<p1>"] = 0.9
     cgp.local_search.gradient_based(ind, objective, 0.05, 1)
-    assert ind.genome.parameter_names_to_values["<p1>"] == pytest.approx(0.91)
+    assert ind.genome._parameter_names_to_values["<p1>"] == pytest.approx(0.91)
 
     # test decrease parameter value if too large
-    ind.genome.parameter_names_to_values["<p1>"] = 1.1
+    ind.genome._parameter_names_to_values["<p1>"] = 1.1
     cgp.local_search.gradient_based(ind, objective, 0.05, 1)
-    assert ind.genome.parameter_names_to_values["<p1>"] == pytest.approx(1.09)
+    assert ind.genome._parameter_names_to_values["<p1>"] == pytest.approx(1.09)
 
     # test no change of parameter value if at optimum
-    ind.genome.parameter_names_to_values["<p1>"] = 1.0
+    ind.genome._parameter_names_to_values["<p1>"] = 1.0
     cgp.local_search.gradient_based(ind, objective, 0.05, 1)
-    assert ind.genome.parameter_names_to_values["<p1>"] == pytest.approx(1.0)
+    assert ind.genome._parameter_names_to_values["<p1>"] == pytest.approx(1.0)
 
 
 def test_gradient_based_step_towards_maximum_multi_genome():
@@ -53,22 +53,22 @@ def test_gradient_based_step_towards_maximum_multi_genome():
         return loss
 
     # test increase parameter value if too small
-    ind.genome[0].parameter_names_to_values["<p1>"] = 0.9
-    ind.genome[1].parameter_names_to_values["<p1>"] = 0.9
+    ind.genome[0]._parameter_names_to_values["<p1>"] = 0.9
+    ind.genome[1]._parameter_names_to_values["<p1>"] = 0.9
     cgp.local_search.gradient_based(ind, objective, 0.05, 1)
-    assert ind.genome[0].parameter_names_to_values["<p1>"] == pytest.approx(0.91)
-    assert ind.genome[1].parameter_names_to_values["<p1>"] == pytest.approx(0.92)
+    assert ind.genome[0]._parameter_names_to_values["<p1>"] == pytest.approx(0.91)
+    assert ind.genome[1]._parameter_names_to_values["<p1>"] == pytest.approx(0.92)
 
     # test decrease parameter value if too large
-    ind.genome[0].parameter_names_to_values["<p1>"] = 1.1
-    ind.genome[1].parameter_names_to_values["<p1>"] = 1.1
+    ind.genome[0]._parameter_names_to_values["<p1>"] = 1.1
+    ind.genome[1]._parameter_names_to_values["<p1>"] = 1.1
     cgp.local_search.gradient_based(ind, objective, 0.05, 1)
-    assert ind.genome[0].parameter_names_to_values["<p1>"] == pytest.approx(1.09)
-    assert ind.genome[1].parameter_names_to_values["<p1>"] == pytest.approx(1.08)
+    assert ind.genome[0]._parameter_names_to_values["<p1>"] == pytest.approx(1.09)
+    assert ind.genome[1]._parameter_names_to_values["<p1>"] == pytest.approx(1.08)
 
     # test no change of parameter value if at optimum
-    ind.genome[0].parameter_names_to_values["<p1>"] = 1.0
-    ind.genome[1].parameter_names_to_values["<p1>"] = 1.0
+    ind.genome[0]._parameter_names_to_values["<p1>"] = 1.0
+    ind.genome[1]._parameter_names_to_values["<p1>"] = 1.0
     cgp.local_search.gradient_based(ind, objective, 0.05, 1)
-    assert ind.genome[0].parameter_names_to_values["<p1>"] == pytest.approx(1.0)
-    assert ind.genome[1].parameter_names_to_values["<p1>"] == pytest.approx(1.0)
+    assert ind.genome[0]._parameter_names_to_values["<p1>"] == pytest.approx(1.0)
+    assert ind.genome[1]._parameter_names_to_values["<p1>"] == pytest.approx(1.0)


### PR DESCRIPTION
As mentioned in #102 the initial values for `Parameter` nodes were hardcoded in the default function of the `DefaultDict` storing parameter values. This PR introduces a flexible initialization scheme: users can derive new classes from the `Parameter` node which override the `initial_value` function. This function can return arbitrary fixed values, but also random samples from some specified distribution.

This PR also changes access to `Genome.dna` to always use the getter/setter functions. This way we can make sure the dna is always in a valid state (via `validate_dna`) without having to perform the validation anywhere else.

closes #102 