### PR TITLE
Provide possibility to restrict local search to k best individuals

### DIFF
--- a/examples/example_differential_evo_regression.py
+++ b/examples/example_differential_evo_regression.py
@@ -70,7 +70,13 @@ def evolution():
         "primitives": (cgp.Add, cgp.Sub, cgp.Mul, cgp.Parameter),
     }
 
-    ea_params = {"n_offsprings": 4, "n_breeding": 4, "tournament_size": 1, "n_processes": 1}
+    ea_params = {
+        "n_offsprings": 4,
+        "n_breeding": 4,
+        "tournament_size": 1,
+        "n_processes": 1,
+        "k_local_search": 2,
+    }
 
     evolve_params = {"max_generations": 2000, "min_fitness": 0.0}
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -48,3 +48,8 @@ def population_simple_fitness(population_params, genome_params):
         parent.fitness = float(i)
 
     return pop
+
+
+@fixture
+def local_search_params():
+    return {"lr": 1e-3, "gradient_steps": 9}

--- a/test/test_ea_mu_plus_lambda.py
+++ b/test/test_ea_mu_plus_lambda.py
@@ -57,3 +57,50 @@ def test_offspring_individuals_are_assigned_correct_indices(population_params, g
 
     for idx, ind in enumerate(offsprings):
         assert ind.idx == len(pop.parents) + idx
+
+
+def test_local_search_is_only_applied_to_best_k_individuals(
+    population_params, local_search_params
+):
+
+    torch = pytest.importorskip("torch")
+
+    def inner_objective(f):
+        return torch.nn.MSELoss()(torch.Tensor([[1.1]]), f(torch.zeros(1, 1)))
+
+    def objective(ind):
+        if ind.fitness is not None:
+            return ind
+
+        f = ind.to_torch()
+        ind.fitness = -inner_objective(f).item()
+        return ind
+
+    population_params["mutation_rate"] = 0.3
+
+    genome_params = {
+        "n_inputs": 1,
+        "n_outputs": 1,
+        "n_columns": 1,
+        "n_rows": 1,
+        "levels_back": None,
+        "primitives": (cgp.Parameter,),
+    }
+
+    k_local_search = 2
+
+    pop = cgp.Population(**population_params, genome_params=genome_params)
+
+    local_search = functools.partial(
+        cgp.local_search.gradient_based, objective=inner_objective, **local_search_params,
+    )
+
+    ea = cgp.ea.MuPlusLambda(5, 5, 1, local_search=local_search, k_local_search=k_local_search)
+    ea.initialize_fitness_parents(pop, objective)
+    ea.step(pop, objective)
+
+    for idx in range(k_local_search):
+        assert pop[idx].genome._parameter_names_to_values["<p1>"] != pytest.approx(1.0)
+
+    for idx in range(k_local_search, population_params["n_parents"]):
+        assert pop[idx].genome._parameter_names_to_values["<p1>"] == pytest.approx(1.0)


### PR DESCRIPTION
as discussed it can be beneficial to restrict the local search to the `k` best performing individuals (#116). this PR implements this suggestion. as expected this decreases wallclock time when used, e.g., in the `example_differential_evo_regression.py` from ~57s to ~44s when running local search only for the best two individuals instead of the whole population (5 individuals).

closes #116 