### PR TITLE
Refactor setting of individual idx upon creation of new individuals

### DIFF
--- a/cgp/ea/mu_plus_lambda.py
+++ b/cgp/ea/mu_plus_lambda.py
@@ -131,9 +131,9 @@ class MuPlusLambda:
         # resulting individuals
         offsprings = pop.crossover(breeding_pool, self.n_offsprings)
         offsprings = pop.mutate(offsprings)
-        # TODO this call to pop to label individual is quite ugly, find a
-        # better way to track ids of individuals; maybe in the EA?
-        pop._label_new_individuals(offsprings)
+
+        for ind in offsprings:
+            ind.idx = pop.get_idx_for_new_individual()
 
         return offsprings
 

--- a/test/test_ea_mu_plus_lambda.py
+++ b/test/test_ea_mu_plus_lambda.py
@@ -41,3 +41,19 @@ def test_fitness_contains_nan(population_params, genome_params):
     ea = cgp.ea.MuPlusLambda(10, 10, 1)
     ea.initialize_fitness_parents(pop, objective)
     ea.step(pop, objective)
+
+
+def test_offspring_individuals_are_assigned_correct_indices(population_params, genome_params):
+    def objective(ind):
+        ind.fitness = 0.0
+        return ind
+
+    pop = cgp.Population(**population_params, genome_params=genome_params)
+
+    ea = cgp.ea.MuPlusLambda(10, 10, 1)
+    ea.initialize_fitness_parents(pop, objective)
+
+    offsprings = ea._create_new_offspring_generation(pop)
+
+    for idx, ind in enumerate(offsprings):
+        assert ind.idx == len(pop.parents) + idx

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -297,7 +297,7 @@ def test_catch_invalid_allele_in_inactive_region():
 
 def test_individuals_have_different_genome(population_params, genome_params, ea_params):
     def objective(ind):
-        ind.fitness = float(ind.idx)
+        ind.fitness = 1.0
         return ind
 
     pop = cgp.Population(**population_params, genome_params=genome_params)

--- a/test/test_population.py
+++ b/test/test_population.py
@@ -97,3 +97,11 @@ def test_pop_uses_own_rng(population_params, genome_params, rng_seed):
     # expect different individuals in the two populations
     for p_0, p_1 in zip(parents_0, parents_1):
         assert p_0.genome.dna != p_1.genome.dna
+
+
+def test_parent_individuals_are_assigned_correct_indices(population_params, genome_params):
+
+    pop = cgp.Population(**population_params, genome_params=genome_params)
+
+    for idx, ind in enumerate(pop.parents):
+        assert ind.idx == idx


### PR DESCRIPTION
Every individual that is created or cloned is assigned a unique idx, for example, in order to be able to trace the lineage of a certain individual (to be implemented). Hopefully this PR makes the associated code a bit more transparent.