### PR TITLE
Tests/individual multi genome

### DIFF
--- a/cgp/__init__.py
+++ b/cgp/__init__.py
@@ -1,15 +1,7 @@
 from .__version__ import __version__
 from .genome import Genome
 from .cartesian_graph import CartesianGraph
-from .node import (
-    Add,
-    ConstantFloat,
-    Div,
-    Mul,
-    Parameter,
-    Pow,
-    Sub,
-)
+from .node import Add, ConstantFloat, Div, Mul, Parameter, Pow, Sub
 from .population import Population
 
 from .hl_api import evolve
@@ -18,3 +10,5 @@ from . import utils
 from . import ea
 from . import node_factories as node_factories
 from . import local_search
+
+from .individual import IndividualSingleGenome, IndividualMultiGenome


### PR DESCRIPTION
This PR addresses #133 . It simply executes all tests for both `IndividualSingleGenome` and `IndividualMultiGenome` by wrapping the `Genome` into a list for the multi-genome tests.

To keep the additional code to a minimum, I introduced some helper functions.

Edit:
Additionally, I reorganized the tests to use pytest fixtures which makes the test more modular and extending them more scalable. Essentially, the `to_sympy` etc. tests have three dimensions of parameters:
- `individual_type`
- `params` = the combination of genome, primitives, dna, and target function to test for
- `arg_funcs` = the function arguments that the functions are tested for

Edit 2:
I also added a similar test for `to_numpy` which was lacking before.