### PR TITLE
Genome mutate - implements new logic for mutations

### DIFF
--- a/cgp/population.py
+++ b/cgp/population.py
@@ -25,8 +25,7 @@ class Population:
         n_parents : int
             Number of parent individuals.
         mutation_rate : float
-            Rate of mutations determining the number of genes to be
-            mutated for offspring creation, between 0 and 1.
+            Probability of a gene to be mutated, between 0 (excluded) and 1 (included).
         seed : int
             Seed for internal random number generator.
         genome_params : dict
@@ -34,8 +33,8 @@ class Population:
         """
         self.n_parents = n_parents  # number of individuals in parent population
 
-        if not (0.0 < mutation_rate and mutation_rate < 1.0):
-            raise ValueError("mutation rate needs to be in (0, 1)")
+        if not (0.0 < mutation_rate and mutation_rate <= 1.0):
+            raise ValueError("mutation rate needs to be in (0, 1]")
         self._mutation_rate = mutation_rate  # probability of mutation per gene
 
         self.seed = seed

--- a/test/test_ea_mu_plus_lambda.py
+++ b/test/test_ea_mu_plus_lambda.py
@@ -196,6 +196,8 @@ def test_create_new_offspring_and_parent_generation(population_params, genome_pa
         individual.fitness = float(individual.idx)
         return individual
 
+    population_params["mutation_rate"] = 1.0  # ensures every offspring has mutations
+
     pop = cgp.Population(**population_params, genome_params=genome_params)
     ea = cgp.ea.MuPlusLambda(**ea_params)
 

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -3,6 +3,7 @@ import pytest
 
 import cgp
 from cgp.genome import ID_INPUT_NODE, ID_OUTPUT_NODE, ID_NON_CODING_GENE
+from cgp.cartesian_graph import CartesianGraph
 
 
 def test_check_dna_consistency():
@@ -346,89 +347,205 @@ def test_is_gene_in_output_region(rng_seed):
     assert not genome._is_gene_in_output_region(11)
 
 
-def test_mutate_hidden_region(rng_seed):
-    rng = np.random.RandomState(rng_seed)
-    genome = cgp.Genome(1, 1, 3, 1, None, (cgp.Add, cgp.ConstantFloat))
-    dna = [
-        ID_INPUT_NODE,
-        ID_NON_CODING_GENE,
-        ID_NON_CODING_GENE,
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-        0,
-        0,
-        2,
-        ID_OUTPUT_NODE,
-        3,
-        ID_NON_CODING_GENE,
-    ]
-    genome.dna = list(dna)
-    active_regions = cgp.CartesianGraph(genome).determine_active_regions()
-
-    # mutating any gene in inactive region returns True
-    assert genome._mutate_hidden_region(list(dna), 3, active_regions, rng) is True
-    assert genome._mutate_hidden_region(list(dna), 4, active_regions, rng) is True
-    assert genome._mutate_hidden_region(list(dna), 5, active_regions, rng) is True
-
-    # mutating function gene in active region returns False
-    assert genome._mutate_hidden_region(list(dna), 6, active_regions, rng) is False
-    # mutating inactive genes in active region returns True
-    assert genome._mutate_hidden_region(list(dna), 7, active_regions, rng) is True
-    assert genome._mutate_hidden_region(list(dna), 8, active_regions, rng) is True
-
-    # mutating any gene in active region without silent genes returns False
-    assert genome._mutate_hidden_region(list(dna), 9, active_regions, rng) is False
-    assert genome._mutate_hidden_region(list(dna), 10, active_regions, rng) is False
-    assert genome._mutate_hidden_region(list(dna), 11, active_regions, rng) is False
-
-
-def test_mutate_output_region(rng_seed):
-    rng = np.random.RandomState(rng_seed)
-    genome = cgp.Genome(1, 1, 2, 1, None, (cgp.Add,))
-    dna = [
-        ID_INPUT_NODE,
-        ID_NON_CODING_GENE,
-        ID_NON_CODING_GENE,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        ID_OUTPUT_NODE,
-        2,
-        ID_NON_CODING_GENE,
-    ]
-
-    assert genome._mutate_output_region(list(dna), 9, rng) is True
-    assert genome._mutate_output_region(list(dna), 10, rng) is False
-    assert genome._mutate_output_region(list(dna), 11, rng) is True
-
-
-@pytest.mark.parametrize("mutation_rate", [0.02, 0.05, 0.2])
-def test_correct_number_of_mutations(mutation_rate, rng_seed):
-
-    n_inputs = 2
+def test_mutation_rate(rng_seed, mutation_rate):
+    n_inputs = 1
     n_outputs = 1
-    n_columns = 10
-    n_rows = 2
-    levels_back = 5
-    primitives = (cgp.Add, cgp.Sub, cgp.Mul, cgp.Div, cgp.ConstantFloat)
-
+    n_columns = 4
+    n_rows = 3
+    genome = cgp.Genome(n_inputs, n_outputs, n_columns, n_rows, None, (cgp.Add, cgp.Sub))
     rng = np.random.RandomState(rng_seed)
-    genome = cgp.Genome(n_inputs, n_outputs, n_columns, n_rows, levels_back, primitives)
     genome.randomize(rng)
 
-    n_mutations = 0
-    genome_new = genome.clone()
-    genome_new.mutate(mutation_rate, rng)
-    for (gene_0, gene_1) in zip(genome.dna, genome_new.dna):
-        if gene_0 != gene_1:
-            n_mutations += 1
+    def count_n_immutable_genes(n_inputs, n_outputs, n_rows):
+        length_per_region = genome.primitives.max_arity + 1  # function gene + input gene addresses
+        n_immutable_genes = n_inputs * length_per_region  # none of the input genes are mutable
+        n_immutable_genes += n_outputs * (
+            length_per_region - 1
+        )  # only one gene per output can be mutated
+        if n_inputs == 1:
+            n_immutable_genes += (
+                n_rows * genome.primitives.max_arity
+            )  # input gene addresses in the first (hidden) column can't be mutated
+            # if only one input node exists
+        return n_immutable_genes
 
-    n_mutations_expected = int(mutation_rate * len(genome.dna))
-    assert n_mutations == n_mutations_expected
+    def count_mutations(dna0, dna1):
+        n_differences = 0
+        for (allele0, allele1) in zip(dna0, dna1):
+            if allele0 != allele1:
+                n_differences += 1
+        return n_differences
+
+    n_immutable_genes = count_n_immutable_genes(n_inputs, n_outputs, n_rows)
+    n_mutations_mean_expected = mutation_rate * (len(genome.dna) - n_immutable_genes)
+    n_mutations_std_expected = np.sqrt(
+        (len(genome.dna) - n_immutable_genes) * mutation_rate * (1 - mutation_rate)
+    )
+
+    n = 10000
+    n_mutations = []
+    for _ in range(n):
+        dna_old = genome.dna
+        genome.mutate(mutation_rate, rng)
+        n_mutations.append(count_mutations(dna_old, genome.dna))
+
+    assert np.mean(n_mutations) == pytest.approx(n_mutations_mean_expected, rel=0.04)
+    assert np.std(n_mutations) == pytest.approx(n_mutations_std_expected, rel=0.04)
+
+
+def test_only_silent_mutations(genome_params, mutation_rate, rng_seed):
+    genome = cgp.Genome(**genome_params)
+    rng = np.random.RandomState(rng_seed)
+    genome.randomize(rng)
+
+    only_silent_mutations = genome.mutate(mutation_rate=0, rng=rng)
+    assert only_silent_mutations is True
+
+    only_silent_mutations = genome.mutate(mutation_rate=1, rng=rng)
+    assert not only_silent_mutations
+
+    dna_fixed = [
+        ID_INPUT_NODE,
+        ID_NON_CODING_GENE,
+        ID_NON_CODING_GENE,
+        ID_INPUT_NODE,
+        ID_NON_CODING_GENE,
+        ID_NON_CODING_GENE,
+        2,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        ID_OUTPUT_NODE,
+        2,
+        ID_NON_CODING_GENE,
+    ]
+    genome.dna = dna_fixed
+    graph = CartesianGraph(genome)
+    active_regions = graph.determine_active_regions()
+    length_per_region = genome.primitives.max_arity + 1  # function gene + input gene addresses
+    gene_to_be_mutated_non_active = (
+        3 * length_per_region
+    )  # operator gene of 2nd hidden node, a silent node in this dna configuration
+
+    def select_gene_indices_silent(mutation_rate, rng):
+        selected_gene_indices = [gene_to_be_mutated_non_active]
+        return selected_gene_indices
+
+    genome._select_gene_indices_for_mutation = (
+        select_gene_indices_silent  # monkey patch the selection of indices to select a silent gene
+    )
+    genome.dna = dna_fixed
+    only_silent_mutations = genome.mutate(mutation_rate, rng)
+    assert only_silent_mutations is True
+
+    gene_to_be_mutated_active = (
+        active_regions[-1] * length_per_region
+    )  # operator gene of the 1st active hidden node,
+    # should always be mutable and result in a non-silent-mutation
+
+    def select_gene_indices_non_silent(mutation_rate, rng):
+        selected_gene_indices = [gene_to_be_mutated_active]
+        return selected_gene_indices
+
+    genome._select_gene_indices_for_mutation = select_gene_indices_non_silent
+    # monkey patch the selection of indices to select a non-silent gene
+    only_silent_mutations = genome.mutate(mutation_rate, rng)
+    assert not only_silent_mutations
+
+
+def test_permissible_values_hidden(rng_seed):
+    genome_params = {
+        "n_inputs": 2,
+        "n_outputs": 1,
+        "n_columns": 3,
+        "n_rows": 3,
+        "levels_back": 2,
+        "primitives": (cgp.Add, cgp.Sub, cgp.ConstantFloat),
+    }
+
+    genome = cgp.Genome(**genome_params)
+
+    # test function gene
+    gene_idx = 6  # function gene of first hidden region
+    allele = 0  #
+    region_idx = None  # can be any number, since not touched for function gene
+    permissible_func_gene_values = genome._determine_alternative_permissible_values_hidden_gene(
+        gene_idx, allele, region_idx
+    )
+    assert permissible_func_gene_values == [
+        1,
+        2,
+    ]  # function idx 1,2 (cgp.Sub, cgp.ConstantFloat)
+
+    # test input gene
+    gene_idx = 16  # first input gene in second column of hidden region
+    allele = 0
+    region_idx = gene_idx // (
+        genome.primitives.max_arity + 1
+    )  # function gene + input gene addresses
+    permissible_input_gene_values = genome._determine_alternative_permissible_values_hidden_gene(
+        gene_idx, allele, region_idx
+    )
+
+    assert permissible_input_gene_values == [
+        1,
+        2,
+        3,
+        4,
+    ]  # gene indices of input, 1st hidden layer
+
+
+def test_permissible_values_output(rng_seed):
+    genome_params = {
+        "n_inputs": 2,
+        "n_outputs": 1,
+        "n_columns": 3,
+        "n_rows": 3,
+        "levels_back": 2,
+        "primitives": (cgp.Add, cgp.Sub, cgp.ConstantFloat),
+    }
+    genome = cgp.Genome(**genome_params)
+
+    gene_idx_function = 33
+    gene_idx_input0 = 34
+    gene_idx_input1 = 35
+
+    allele = 5  # set current value for input0 -> should be excluded from permissible values
+
+    permissible_values = genome._determine_alternative_permissible_values_output_gene(
+        gene_idx_function, allele
+    )
+    assert permissible_values == []
+
+    permissible_values = genome._determine_alternative_permissible_values_output_gene(
+        gene_idx_input0, allele
+    )
+    assert permissible_values == [0, 1, 2, 3, 4, 6, 7, 8, 9, 10]
+
+    permissible_values = genome._determine_alternative_permissible_values_output_gene(
+        gene_idx_input1, allele
+    )
+    assert permissible_values == []

--- a/test/test_hl_api.py
+++ b/test/test_hl_api.py
@@ -65,6 +65,7 @@ def test_parallel_population(population_params, genome_params, ea_params):
         fitness_per_n_processes.append(
             _test_population(population_params, genome_params, ea_params)
         )
+
     assert fitness_per_n_processes[0] == pytest.approx(fitness_per_n_processes[1])
     assert fitness_per_n_processes[0] == pytest.approx(fitness_per_n_processes[2])
 


### PR DESCRIPTION
Implements the new logic for mutation discussed in #172. Closes #172 , #173 and makes #124 obsolete. Does not pass  `test_parallel_population` in test/test_hl_api.py, since fitnes is not the with 1 or 2 parallel processes. I created the PR anyway since I couldn't figure out why and whether this is a problem with the new logic in mutate