### PR TITLE
Fix relative path to image in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,13 +26,17 @@ Cartesian genetic programming (CGP) in pure Python.
 
 This library implements Cartesian genetic programming (e.g, Miller and Thomson, 2000; Miller, 2011) for symbolic regression in pure Python, targeting applications with expensive fitness evaluations. It provides Python data structures to represent and evolve two-dimensional directed graphs (genotype) that are translated into computational graphs (phenotype) implementing mathematical expressions. The computational graphs can be compiled as a Python functions, SymPy expressions (Meurer et al., 2017) or PyTorch modules (Paszke et al., 2017). The library currently implements an evolutionary algorithm, specifically (mu + lambda) evolution strategies adapted from Deb et al. (2002), to evolve a population of symbolic expressions in order to optimize an objective function.
 
-.. image:: ../cgp-sketch.png
+.. image-start
+   
+.. image:: ./cgp-sketch.png
    :width: 600
    :alt: CGP Sketch
 	 
 Figure from Jordan, Schmidt, Senn & Petrovici, "Evolving to learn: discovering interpretable plasticity rules for spiking networks", arxiv:2005.14149_.
 
 .. _arxiv:2005.14149: https://arxiv.org/abs/2005.14149
+
+.. image-end
 
 .. long-description-end
 
@@ -160,3 +164,5 @@ Citation
 If you use HAL-CGP in your work, please cite it as:
 
 Schmidt, Maximilian & Jordan, Jakob (2020) hal-cgp: Cartesian genetic programming in pure Python. [10.5281/zenodo.3889163](https://doi.org/10.5281/zenodo.3889163)
+
+.. citation-end

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,8 +4,17 @@
    contain the root `toctree` directive.
 
 .. include:: ../README.rst
-   :end-before: long-description-end
-	     
+   :end-before: image-start
+
+.. image:: ../cgp-sketch.png
+   :width: 600
+   :alt: CGP Sketch
+	 
+Figure from Jordan, Schmidt, Senn & Petrovici, "Evolving to learn: discovering interpretable plasticity rules for spiking networks", arxiv:2005.14149_.
+
+.. _arxiv:2005.14149: https://arxiv.org/abs/2005.14149
+
+
 .. toctree::
    :maxdepth: 2
 


### PR DESCRIPTION
This is a hotfix to make the image appear properly in the README again, bug was introduced in #181 .

I fixed the relative path in the README file, and changed the logic of including the header in `index.rst`: It now only includes the text, but not the image. Instead, the image is included explicitly with a correct relative path. This introduces a slight duplicate of code between README and documentation index, but this is inevitable, unfortunately. 

It is possible to use absolute paths in the README, but this will break the documentation because sphinx does not handle absolute paths. Supposedly, it should be able to (see https://stackoverflow.com/questions/52138336/sphinx-reference-to-an-image-from-different-locations), but just like for the person asking the question in that link, it does not work for me.

See https://github.com/Happy-Algorithms-League/hal-cgp/tree/hotfix/README_figure to check the fixed README with correctly displayed image.