### PR TITLE
Add deployment of documentation on github pages to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,16 @@ python:
   - "3.8"
 env:
   - DEP=[all]
-  - DEP=
+  - DEP=[dev]
 branches:
   only:
     - master
 jobs:
   exclude:
   - python: "3.6"
-    env: DEP=
+    env: DEP=[dev]
   - python: "3.7"
-    env: DEP=
+    env: DEP=[dev]
 before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
@@ -24,16 +24,16 @@ before_install:
   - source activate myenv
   - pip install --upgrade pip
 install:
-  - pip install pytest pytest-cov coveralls
-  - pip install flake8 black
-  - pip install mypy
   - pip install -e .$DEP
+  - pip install pytest-cov coveralls
 script:
   - black --check .
   - flake8 --config=.flake8 .
   - mypy cgp
   - if [ "$DEP" = "[all]" ]; then
-       cd docs && make html && cd ../ || exit 1;
+       make -C docs/ html || exit 1;
+       touch docs/_build/html/.nojekyll
+       
     fi
   - pytest --cov=cgp
   - if [ "$DEP" = "[all]" -a $TRAVIS_PYTHON_VERSION = 3.8 ]; then
@@ -43,3 +43,14 @@ script:
     fi
 after_success:
   - coveralls
+deploy:
+  provider: pages:git
+  skip_cleanup: true
+  verbose: true
+  token: $GITHUB_TOKEN
+  edge: true
+  local_dir: ./docs/_build/html/
+  keep_history: true
+  on:
+    python: 3.8
+    condition: $DEP = "[all]"

--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,8 @@
 	   :target: https://github.com/psf/black
 .. image:: https://coveralls.io/repos/github/Happy-Algorithms-League/python-gp/badge.svg?branch=master
 	   :target: https://coveralls.io/github/Happy-Algorithms-League/python-gp?branch=master
+.. image:: https://readthedocs.org/projects/ansicolortags/badge/?version=latest
+	   :target: https://happy-algorithms-league.github.io/hal-cgp/
 
 Cartesian genetic programming (CGP) in pure Python.
 
@@ -35,8 +37,6 @@ Figure from Jordan, Schmidt, Senn & Petrovici, "Evolving to learn: discovering i
 .. _arxiv:2005.14149: https://arxiv.org/abs/2005.14149
 
 .. long-description-end
-
-A simple example of CGP applied to a symbolic regression problem can be found in `examples/example_evo_regression.py`.
 
 .. installation-start
 ============
@@ -72,10 +72,13 @@ The adventurous can install the most recent development version directly from ou
 
 .. installation-end
 
-.. basic-usage-start
 ===========
 Basic usage
 ===========
+
+For detailed documentation, please refer to `https://happy-algorithms-league.github.io/hal-cgp/ <https://happy-algorithms-league.github.io/hal-cgp/>`_. Here we only provide a preview.
+
+.. basic-usage-start
 
 Follow these steps to solve a basic regression problem:
 

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -1,0 +1,7 @@
+===========
+Basic usage
+===========
+
+.. include:: ../README.rst
+   :start-after: basic-usage-start
+   :end-before: basic-usage-end


### PR DESCRIPTION
This fixes #184 .

First we build the documentation in one of the jobs (I simplified the command here) and place a `.nojekyll` file in the html folder (which tells github pages that we're not using jekyll as a static site builder).
In addition, the PR adds a deploy stage to travis CI, which will push the contents of `doc/_build/html` .

I followed the steps in this tutorial: https://medium.com/@FelipeFaria/sphinx-travis-ci-github-pages-full-integration-for-auto-docs-publishing-91ce93179e17

Update:
I also added a bit of simplification to the travis file:
- I refactored the documentation building line
- Instead of installing not extra requirements, we're installing the `[dev]` requirements in the last job so that we can skip the manual install of `black`, `mypy`, and `flake8`.

I also added references to the documentation to the README.