### PR TITLE
Fix travis link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@
 	   :target: https://www.python.org/
 .. image:: https://img.shields.io/badge/License-GPLv3-blue.svg
 	   :target: https://www.gnu.org/licenses/old-licenses/gpl-3.0.html
-.. image:: https://api.travis-ci.org/Happy-Algorithms-League/hal-cgp.svg?branch=master)
+.. image:: https://travis-ci.org/Happy-Algorithms-League/hal-cgp.svg?branch=master
 	   :target: https://travis-ci.org/Happy-Algorithms-League/hal-cgp
 .. image:: http://www.mypy-lang.org/static/mypy_badge.svg
 	   :target: http://mypy-lang.org/


### PR DESCRIPTION
Quick fix of the broken link to the Travis badge in the README. Apparently, the link is different for markdown README files and RST README files and there was a redundant `)` which led to the failing mypy badge in the docs. 

Fixes #197 