### PR TITLE
Add links to source code on github to API docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,6 +10,8 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+import cgp
+import inspect
 import os
 import sys
 import msmb_theme
@@ -32,7 +34,12 @@ release = "0.1.1"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "recommonmark", "sphinx_gallery.gen_gallery"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.linkcode",
+    "recommonmark",
+    "sphinx_gallery.gen_gallery",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -63,3 +70,57 @@ sphinx_gallery_conf = {
     "examples_dirs": "../examples",  # path to your example scripts
     "gallery_dirs": "auto_examples",  # path to where to save gallery generated output
 }
+
+
+def linkcode_resolve(domain, info):
+    """
+    Determine the URL corresponding to Python object.
+
+    Code from the Numpy repository:
+    https://github.com/numpy/numpy/blob/a0028bca0117874606bce99261d978df8d3f6610/doc/source/conf.py#L332
+    """
+    if domain != "py":
+        return None
+
+    modname = info["module"]
+    fullname = info["fullname"]
+
+    submod = sys.modules.get(modname)
+    if submod is None:
+        return None
+
+    obj = submod
+    for part in fullname.split("."):
+        try:
+            obj = getattr(obj, part)
+        except Exception:
+            return None
+
+    # strip decorators, which would resolve to the source of the decorator
+    # possibly an upstream bug in getsourcefile, bpo-1764286
+    try:
+        unwrap = inspect.unwrap
+    except AttributeError:
+        pass
+    else:
+        obj = unwrap(obj)
+
+    try:
+        fn = inspect.getsourcefile(obj)
+    except Exception:
+        fn = None
+    if not fn:
+        return None
+
+    try:
+        source, lineno = inspect.getsourcelines(obj)
+    except Exception:
+        lineno = None
+
+    if lineno:
+        linespec = f"#L{lineno}-L{lineno + len(source) - 1}"
+    else:
+        linespec = ""
+
+    fn = os.path.relpath(fn, start=os.path.dirname(cgp.__file__))
+    return f"https://github.com/Happy-Algorithms-League/hal-cgp/blob/master/cgp/{fn}{linespec}"


### PR DESCRIPTION
This PR adds links to the source code to the API docs in the documentation.

To achieve, we:
- add linkcode extension of sphinx
- add linkcode_resolve function from numpy docs (see https://github.com/numpy/numpy/blob/a0028bca0117874606bce99261d978df8d3f6610/doc/source/conf.py#L332)