### PR TITLE
Fix reproducability in mountain_car example

### DIFF
--- a/examples/example_mountain_car.py
+++ b/examples/example_mountain_car.py
@@ -61,8 +61,8 @@ def inner_objective(f, seed, n_total_steps, *, render):
 
     env = gym.make("MountainCarContinuous-v0")
 
-    observation = env.reset()
     env.seed(seed)
+    observation = env.reset()
 
     cum_reward_all_episodes = []
     cum_reward_this_episode = 0


### PR DESCRIPTION
Done by setting the seed before sampling observations. Not done for the visualization of the champion in the end. Closes #202 