### PR TITLE
Use figures from examples in documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,18 +30,12 @@ script:
   - black --check .
   - flake8 --config=.flake8 .
   - mypy cgp
-  - if [ "$DEP" = "[all]" ]; then
+  - if [ "$DEP" = "[all]" -a $TRAVIS_PYTHON_VERSION = 3.8 ]; then
+       pip install gym || exit 1;
        make -C docs/ html || exit 1;
-       touch docs/_build/html/.nojekyll
-       
+       touch docs/_build/html/.nojekyll || exit 1;
     fi
   - pytest --cov=cgp
-  - if [ "$DEP" = "[all]" -a $TRAVIS_PYTHON_VERSION = 3.8 ]; then
-       python examples/example_evo_regression.py || exit 1 ;
-       python examples/example_differential_evo_regression.py || exit 1;
-       python examples/example_caching.py || exit 1;
-       python examples/example_parametrized_nodes.py || exit 1;
-    fi
 after_success:
   - coveralls
 deploy:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,3 +18,12 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+clean:
+	rm -rf $(BUILDDIR)/*
+	rm -rf auto_examples/
+
+html-noplot:
+	$(SPHINXBUILD) -D plot_gallery=0 -b html $(SOURCEDIR) $(BUILDDIR)/html
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,8 +67,11 @@ html_static_path = ["_static"]
 # -- Options for Sphinx Gallery ---------------------------------------------
 
 sphinx_gallery_conf = {
+    "filename_pattern": "/*.py",
     "examples_dirs": "../examples",  # path to your example scripts
     "gallery_dirs": "auto_examples",  # path to where to save gallery generated output
+    "matplotlib_animations": True,
+    "image_scrapers": ("matplotlib",),
 }
 
 

--- a/examples/example_mountain_car.py
+++ b/examples/example_mountain_car.py
@@ -268,6 +268,8 @@ def visualize_behaviour_for_evolutionary_jumps(seed, history, only_final_solutio
 
 # %%
 # Finally, we execute the evolution and visualize the results.
+# To animate the behavior of the car for the found expression, uncomment
+# the last line of the example.
 
 
 if __name__ == "__main__":
@@ -285,4 +287,4 @@ if __name__ == "__main__":
 
     plot_fitness_over_generation_index(history)
     evaluate_champion(champion)
-    visualize_behaviour_for_evolutionary_jumps(seed, history)
+    # visualize_behaviour_for_evolutionary_jumps(seed, history)


### PR DESCRIPTION
This PR does the following this:

- It configures sphinx such that the gallery of examples will contain the images produced by the example scripts. To that end, running `make html`  in the `docs/` folder now executes the example scripts one by one and collects the figures created by the scripts.
- To enable quick debugging of the documentation without having to run the examples every time, I introduced `make html-noplot` which skips running the examples (and produces a documentation without the figures). This is of much quicker to run.
- In the CI, I removed the step to run the examples explicitly because this is now done in the documentation build step, implicitly.

Note: It is not possible to render the openAI gym environment when running the mountain car example script with sphinx-gallery. (This will fail with an error). I suspect the problem is that the `pyglet` library that the gym is using for rendering does not support headless rendering (this is a known shortcoming of this library). Therefore, the only possible way to make the docs run is to comment out this line in the example. I added an explanation to the docstring.

To test this PR, run
```bash
cd docs/
make html
```