### PR TITLE
Extend cache decorator with functional equivalence checking

### DIFF
--- a/cgp/cartesian_graph.py
+++ b/cgp/cartesian_graph.py
@@ -408,8 +408,7 @@ class _C(torch.nn.Module):
             s = self._fill_parameter_values(s)
             # to get an expression that reflects the computational graph,
             # sympy should not automatically simplify the expression
-            with sympy.evaluate(False):
-                sympy_exprs.append(sympy.sympify(s))
+            sympy_exprs.append(sympy.sympify(s, evaluate=False))
 
         if not simplify:
             return sympy_exprs

--- a/test/test_cartesian_graph.py
+++ b/test/test_cartesian_graph.py
@@ -351,19 +351,20 @@ def test_to_sympy():
     primitives = (cgp.Add, cgp.ConstantFloat)
     genome = cgp.Genome(1, 1, 2, 2, 1, primitives)
 
+    # f = x_0 + x_0 + 1.0
     genome.dna = [
         ID_INPUT_NODE,
         ID_NON_CODING_GENE,
         ID_NON_CODING_GENE,
-        1,
-        0,
-        0,
-        1,
-        0,
         0,
         0,
         0,
         1,
+        0,
+        0,
+        0,
+        1,
+        2,
         0,
         0,
         1,
@@ -373,15 +374,16 @@ def test_to_sympy():
     ]
     graph = cgp.CartesianGraph(genome)
 
-    x_0_target, y_0_target = sympy.symbols("x_0_target y_0_target")
-    y_0_target = x_0_target + 1.0
+    y_0_target = sympy.sympify("x_0 + x_0 + 1.0", evaluate=False)
+    y_0 = graph.to_sympy(simplify=False)[0]
+    assert y_0_target == y_0
 
+    y_0_target = sympy.sympify("2 * x_0 + 1.0", evaluate=True)
     y_0 = graph.to_sympy()[0]
+    assert y_0_target == y_0
 
     for x in np.random.normal(size=100):
-        assert pytest.approx(
-            y_0_target.subs("x_0_target", x).evalf() == y_0.subs("x_0", x).evalf()
-        )
+        assert y_0_target.subs("x_0", x).evalf() == pytest.approx(y_0.subs("x_0", x).evalf())
 
 
 def test_allow_sympy_expr_with_infinities():

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -9,6 +9,73 @@ import pytest
 import cgp
 
 
+@pytest.mark.parametrize("individual_type", ["SingleGenome", "MultiGenome"])
+def test_cache_decorator_produces_identical_history(
+    individual_type, rng_seed, population_params, genome_params, ea_params
+):
+    pytest.importorskip("sympy")
+
+    evolve_params = {"max_generations": 10, "min_fitness": 0.0}
+
+    def f_target(x):
+        return x[0] - x[1]
+
+    def inner_objective(expr):
+        np.random.seed(rng_seed)
+
+        if individual_type == "SingleGenome":
+            expr_unpacked = expr[0]
+        elif individual_type == "MultiGenome":
+            expr_unpacked = expr[0][0]
+        else:
+            raise NotImplementedError
+
+        loss = 0
+        for x in np.random.uniform(size=(5, 2)):
+            loss += (
+                f_target(x) - float(expr_unpacked.subs({"x_0": x[0], "x_1": x[1]}).evalf())
+            ) ** 2
+        return loss
+
+    @cgp.utils.disk_cache(tempfile.mkstemp()[1])
+    def inner_objective_decorated(expr):
+        return inner_objective(expr)
+
+    def evolve(inner_objective):
+        def objective(ind):
+            ind.fitness = -inner_objective(ind.to_sympy())
+            return ind
+
+        if individual_type == "SingleGenome":
+            pop = cgp.Population(**population_params, genome_params=genome_params)
+        elif individual_type == "MultiGenome":
+            pop = cgp.Population(**population_params, genome_params=[genome_params])
+        else:
+            raise NotImplementedError
+
+        ea = cgp.ea.MuPlusLambda(**ea_params)
+
+        history = {}
+        history["fitness_champion"] = []
+
+        def recording_callback(pop):
+            history["fitness_champion"].append(pop.champion.fitness)
+
+        cgp.evolve(
+            pop, objective, ea, **evolve_params, print_progress=True, callback=recording_callback
+        )
+
+        return history
+
+    history = evolve(inner_objective)
+    history_decorated = evolve(inner_objective_decorated)
+
+    for fitness, fitness_decorated in zip(
+        history["fitness_champion"], history_decorated["fitness_champion"]
+    ):
+        assert fitness == pytest.approx(fitness_decorated)
+
+
 @cgp.utils.disk_cache(tempfile.mkstemp()[1])
 def _cache_decorator_objective_single_process(s, sleep_time):
     time.sleep(sleep_time)  # simulate long execution time


### PR DESCRIPTION
This PR implements functional equivalence checking (see, e.g., https://arxiv.org/abs/2003.03384) to allow caching of (inner) objectives that are  called with individuals, not SymPy expressions. Functionally identical individuals are identified by evaluating them on a certain number of random input samples and hashing the output values.

This PR also increases the number of generations in the cache decorator example to allow evolution to converge, and adds a test that makes sure that the fitness history is identical with and without cache decorator.

~**WARNING** Currently I need to disable one other test to make the new tests pass. There is some really weird interaction on the SymPy level that I couldn't figure out yet. :|~

closes #61 