### PR TITLE
Use norm clipping instead of value clipping to avoid changing the direction of the gradient

### DIFF
--- a/cgp/local_search/gradient_based.py
+++ b/cgp/local_search/gradient_based.py
@@ -80,7 +80,7 @@ def gradient_based(
 
             loss.backward()
             if clip_value is not np.inf:
-                torch.nn.utils.clip_grad.clip_grad_value_(params, clip_value)
+                torch.nn.utils.clip_grad.clip_grad_norm_(params, clip_value)
 
             optimizer.step()
 


### PR DESCRIPTION
while clipping/thresholding values in the gradient vector can change its direction, rescaling all values to achieve a certain vector norm leaves (by definition) the orientation invariant (see, e.g., https://stackoverflow.com/questions/44796793/difference-between-tf-clip-by-value-and-tf-clip-by-global-norm-for-rnns-and-how/44798131#44798131, https://arxiv.org/pdf/1211.5063.pdf). so if we do not have a significant motivation to use `...clip_grad_value`, we should avoid using it.