### PR TITLE
Fix parameters being reininitialized in Genome.mutate()

### DIFF
--- a/cgp/genome.py
+++ b/cgp/genome.py
@@ -528,6 +528,7 @@ class Genome:
             assert issubclass(node_type, OperatorNode)
             for parameter_name in node_type._parameter_names:
                 parameter_name_with_idx = "<" + parameter_name[1:-1] + str(region_idx) + ">"
-                self._parameter_names_to_values[parameter_name_with_idx] = node_type.initial_value(
-                    parameter_name_with_idx
-                )
+                if parameter_name_with_idx not in self._parameter_names_to_values:
+                    self._parameter_names_to_values[
+                        parameter_name_with_idx
+                    ] = node_type.initial_value(parameter_name_with_idx)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,4 @@
+import numpy as np
 from pytest import fixture
 
 import cgp
@@ -6,6 +7,11 @@ import cgp
 @fixture
 def rng_seed():
     return 1234
+
+
+@fixture
+def rng(rng_seed):
+    return np.random.RandomState(rng_seed)
 
 
 @fixture

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -1,3 +1,4 @@
+import math
 import numpy as np
 import pytest
 
@@ -534,3 +535,15 @@ def test_permissible_values(genome_params):
         permissible_values_expected, genome._permissible_values
     ):
         assert np.all(pv_per_gene_expected == pv_per_gene)
+
+
+def test_mutate_does_not_reinitialize_parameters(genome_params, rng, mutation_rate):
+    genome_params["primitives"] = (cgp.Parameter,)
+    genome = cgp.Genome(**genome_params)
+    genome.randomize(rng)
+    genome._parameter_names_to_values["<p2>"] = math.pi
+    parameter_names_to_values_before = genome._parameter_names_to_values.copy()
+    genome.mutate(mutation_rate, rng)
+    assert genome._parameter_names_to_values["<p2>"] == pytest.approx(
+        parameter_names_to_values_before["<p2>"]
+    )


### PR DESCRIPTION
As `mutate` uses `dna.setter` it also triggers the function to initialize numerical values for (unknown) parameters. Before initializing any parameter it is now checked that this does have a value assigned yet. If it does, this parameter is not (re)initialized.

(ouch! :grimacing: )