### PR TITLE
Reduce mutation rate in evo regression example to achieve convergence

### DIFF
--- a/examples/example_evo_regression.py
+++ b/examples/example_evo_regression.py
@@ -109,7 +109,7 @@ def evolution(f_target):
     Individual
         Individual with the highest fitness in the last generation
     """
-    population_params = {"n_parents": 10, "mutation_rate": 0.05, "seed": 8188211}
+    population_params = {"n_parents": 10, "mutation_rate": 0.03, "seed": 8188211}
 
     genome_params = {
         "n_inputs": 2,


### PR DESCRIPTION
the evo_regression example currently does not converge for the easy function (https://happy-algorithms-league.github.io/hal-cgp/auto_examples/example_evo_regression.html#sphx-glr-auto-examples-example-evo-regression-py). this PR adapts the mutation rate to make sure the example converges within the specified number of generations.