### PR TITLE
Add command line args for example scripts

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,3 +4,5 @@ max-line-length = 99
 max-complexity = 18
 select = B,C,E,F,W,T4,B9
 exclude = __init__.py
+per-file-ignores =
+    examples/*:E402

--- a/examples/example_differential_evo_regression.py
+++ b/examples/example_differential_evo_regression.py
@@ -20,14 +20,29 @@ References:
 
 """
 
+# The docopt str is added explicitly to ensure compatibility with
+# sphinx-gallery.
+docopt_str = """
+  Usage:
+    example_differential_evo_regression.py [--max-generations=<N>]
+
+  Options:
+    -h --help
+    --max-generations=<N>  Maximum number of generations [default: 2000]
+
+"""
+
 import functools
 
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.constants
 import torch
+from docopt import docopt
 
 import cgp
+
+args = docopt(docopt_str)
 
 # %%
 # We first define the target function. Note that this function contains
@@ -92,7 +107,7 @@ genome_params = {
 
 ea_params = {"n_offsprings": 4, "tournament_size": 1, "n_processes": 1, "k_local_search": 2}
 
-evolve_params = {"max_generations": 2000, "min_fitness": 0.0}
+evolve_params = {"max_generations": int(args["--max-generations"]), "min_fitness": 0.0}
 
 # use an uneven number of gradient steps so they can not easily
 # average out for clipped values

--- a/examples/example_evo_regression.py
+++ b/examples/example_evo_regression.py
@@ -6,6 +6,16 @@ Example demonstrating the use of Cartesian genetic programming for
 two regression tasks.
 """
 
+# The docopt str is added explicitly to ensure compatibility with
+# sphinx-gallery.
+docopt_str = """
+   Usage:
+     example_evo_regression.py [--max-generations=<N>]
+
+   Options:
+     -h --help
+     --max-generations=<N>  Maximum number of generations [default: 1000]
+"""
 
 import functools
 import warnings
@@ -13,8 +23,11 @@ import warnings
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.constants
+from docopt import docopt
 
 import cgp
+
+args = docopt(docopt_str)
 
 # %%
 # We first define target functions. For illustration purposes, we
@@ -123,7 +136,7 @@ def evolution(f_target):
 
     ea_params = {"n_offsprings": 10, "tournament_size": 2, "n_processes": 2}
 
-    evolve_params = {"max_generations": 1000, "min_fitness": 0.0}
+    evolve_params = {"max_generations": int(args["--max-generations"]), "min_fitness": 0.0}
 
     # create population that will be evolved
     pop = cgp.Population(**population_params, genome_params=genome_params)

--- a/examples/example_mountain_car.py
+++ b/examples/example_mountain_car.py
@@ -12,6 +12,17 @@ Install the OpenAI Gym package: `pip install gym`
 
 """
 
+# The docopt str is added explicitly to ensure compatibility with
+# sphinx-gallery.
+docopt_str = """
+  Usage:
+    example_parametrized_nodes.py [--max-generations=<N>] [--visualize-final-champion]
+
+  Options:
+    -h --help
+    --max-generations=<N>  Maximum number of generations [default: 1500]
+    --visualize-final-champion  Create animation of final champion in the mountain car env.
+"""
 
 import functools
 import warnings
@@ -19,6 +30,7 @@ import warnings
 import matplotlib.pyplot as plt
 import numpy as np
 import sympy
+from docopt import docopt
 
 import cgp
 
@@ -29,6 +41,8 @@ except ImportError:
         "Failed to import the OpenAI Gym package. Please install it via `pip install gym`."
     )
 
+
+args = docopt(docopt_str)
 
 # %%
 # For more flexibility in the evolved expressions, we define two
@@ -154,7 +168,7 @@ def evolve(seed):
 
     ea_params = {"n_offsprings": 4, "tournament_size": 1, "n_processes": 4}
 
-    evolve_params = {"max_generations": 1500, "min_fitness": 100.0}
+    evolve_params = {"max_generations": int(args["--max-generations"]), "min_fitness": 100.0}
 
     pop = cgp.Population(**population_params, genome_params=genome_params)
 
@@ -288,4 +302,5 @@ if __name__ == "__main__":
 
     plot_fitness_over_generation_index(history)
     evaluate_champion(champion)
-    # visualize_behaviour_for_evolutionary_jumps(seed, history)
+    if args["--visualize-final-champion"]:
+        visualize_behaviour_for_evolutionary_jumps(seed, history)

--- a/examples/example_parametrized_nodes.py
+++ b/examples/example_parametrized_nodes.py
@@ -9,6 +9,17 @@ which produces a scaled and shifted version of the sum of its inputs.
 
 """
 
+# The docopt str is added explicitly to ensure compatibility with
+# sphinx-gallery.
+docopt_str = """
+  Usage:
+    example_parametrized_nodes.py [--max-generations=<N>]
+
+  Options:
+    -h --help
+    --max-generations=<N>  Maximum number of generations [default: 500]
+"""
+
 import functools
 import math
 
@@ -16,8 +27,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 import scipy.constants
 import torch
+from docopt import docopt
 
 import cgp
+
+args = docopt(docopt_str)
 
 # %%
 # We first define a new node that adds two inputs then scales and
@@ -99,7 +113,7 @@ genome_params = {
 
 ea_params = {"n_offsprings": 4, "tournament_size": 1, "n_processes": 2}
 
-evolve_params = {"max_generations": 500, "min_fitness": 0.0}
+evolve_params = {"max_generations": int(args["--max-generations"]), "min_fitness": 0.0}
 
 local_search_params = {"lr": 1e-3, "gradient_steps": 9}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 numpy ~= 1.18.3
+docopt-ng~=0.7.2


### PR DESCRIPTION
This PR implements command-line args for the example scripts. It is the first step to address #208 . In a follow-up PR, I will then make use of these command-line args in the travis CI.

The following things are implemented:
- Add option to specify max_generations on the command line to example scripts
- Add switch for visualization in mountain_car example