### PR TITLE
Maint/isort

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,4 @@
+[settings]
+line_length = 99
+multi_line_output = 3
+include_trailing_comma = True

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    - id: black
+      language_version: python3.8
+      args: [--config=pyproject.toml]
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v1.2.3
+    hooks:
+    - id: flake8
+      args: [--config=.flake8]
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.21
+    hooks:
+    - id: isort

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ script:
   - black --check .
   - flake8 --config=.flake8 .
   - mypy cgp
+  - isort --check-only cgp examples test
   - if [ "$DEP" = "[all]" -a $TRAVIS_PYTHON_VERSION = 3.8 ]; then
        pip install gym || exit 1;
        make -C docs/ html || exit 1;

--- a/cgp/__init__.py
+++ b/cgp/__init__.py
@@ -6,16 +6,11 @@ __description__ = "Cartesian genetic programming (CGP) in pure Python."
 __url__ = "https://happy-algorithms-league.github.io/hal-cgp/"
 __doc__ = f"{__description__} <{__url__}>"
 
-from .genome import Genome
+from . import ea, local_search, utils
 from .cartesian_graph import CartesianGraph
+from .genome import Genome
+from .hl_api import evolve
+from .individual import IndividualMultiGenome, IndividualSingleGenome
 from .node import OperatorNode
 from .node_impl import Add, ConstantFloat, Div, Mul, Parameter, Pow, Sub
 from .population import Population
-
-from .hl_api import evolve
-
-from . import utils
-from . import ea
-from . import local_search
-
-from .individual import IndividualSingleGenome, IndividualMultiGenome

--- a/cgp/cartesian_graph.py
+++ b/cgp/cartesian_graph.py
@@ -1,8 +1,13 @@
 import collections
 import copy
 import math  # noqa: F401
-import numpy as np  # noqa: F401
 import re
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set
+
+import numpy as np  # noqa: F401
+
+from .node import Node, OperatorNode
+from .node_input_output import InputNode, OutputNode
 
 try:
     import sympy
@@ -19,10 +24,6 @@ try:
 except ModuleNotFoundError:
     torch_available = False
 
-from typing import Callable, Dict, List, Optional, Set, TYPE_CHECKING
-
-from .node import Node, OperatorNode
-from .node_input_output import InputNode, OutputNode
 
 if TYPE_CHECKING:
     from .genome import Genome
@@ -372,7 +373,7 @@ class _C(torch.nn.Module):
             for node in active_nodes[hidden_column_idx]:
                 node.format_output_str_sympy(self)
 
-    def to_sympy(self, simplify: Optional[bool] = True,) -> List["sympy_expr.Expr"]:
+    def to_sympy(self, simplify: Optional[bool] = True) -> List["sympy_expr.Expr"]:
         """Compile the function(s) represented by the graph to a SymPy expression.
 
         Generates one SymPy expression for each output node.

--- a/cgp/ea/mu_plus_lambda.py
+++ b/cgp/ea/mu_plus_lambda.py
@@ -1,7 +1,7 @@
 import concurrent.futures
-import numpy as np
-
 from typing import Callable, List, Union
+
+import numpy as np
 
 from ..individual import IndividualBase
 from ..population import Population

--- a/cgp/genome.py
+++ b/cgp/genome.py
@@ -1,4 +1,10 @@
+from typing import Dict, Generator, List, Optional, Tuple, Type, Union
+
 import numpy as np
+
+from .cartesian_graph import CartesianGraph
+from .node import Node, OperatorNode
+from .primitives import Primitives
 
 try:
     import torch  # noqa: F401
@@ -6,12 +12,6 @@ try:
     torch_available = True
 except ModuleNotFoundError:
     torch_available = False
-
-from typing import Dict, Generator, List, Optional, Tuple, Type, Union
-
-from .cartesian_graph import CartesianGraph
-from .node import Node, OperatorNode
-from .primitives import Primitives
 
 
 ID_INPUT_NODE: int = -1
@@ -170,7 +170,7 @@ class Genome:
             permissible_values.append(permissible_values_per_gene)
         return permissible_values
 
-    def _determine_permissible_values_input_region(self, gene_idx: int,) -> np.ndarray:
+    def _determine_permissible_values_input_region(self, gene_idx: int) -> np.ndarray:
 
         if self._is_function_gene(gene_idx):
             return np.array(self._id_input_node)
@@ -190,7 +190,7 @@ class Genome:
         else:
             assert False  # should never be reached
 
-    def _determine_permissible_values_output_region(self, gene_idx: int,) -> np.ndarray:
+    def _determine_permissible_values_output_region(self, gene_idx: int) -> np.ndarray:
 
         if self._is_function_gene(gene_idx):
             return np.array(self._id_output_node)

--- a/cgp/hl_api.py
+++ b/cgp/hl_api.py
@@ -1,9 +1,10 @@
-import numpy as np
-from typing import Optional, Callable
+from typing import Callable, Optional
 
-from .population import Population
-from .individual import IndividualBase
+import numpy as np
+
 from .ea import MuPlusLambda
+from .individual import IndividualBase
+from .population import Population
 
 
 def evolve(

--- a/cgp/individual.py
+++ b/cgp/individual.py
@@ -1,5 +1,9 @@
-import numpy as np
 from typing import Callable, List, Union
+
+import numpy as np
+
+from .cartesian_graph import CartesianGraph
+from .genome import Genome
 
 try:
     import sympy  # noqa: F401
@@ -15,9 +19,6 @@ try:
     torch_available = True
 except ModuleNotFoundError:
     torch_available = False
-
-from .genome import Genome
-from .cartesian_graph import CartesianGraph
 
 
 class IndividualBase:

--- a/cgp/local_search/gradient_based.py
+++ b/cgp/local_search/gradient_based.py
@@ -1,4 +1,8 @@
+from typing import Callable, List, Optional, Union
+
 import numpy as np
+
+from ..individual import IndividualBase
 
 try:
     import torch  # noqa: F401
@@ -7,11 +11,6 @@ try:
     torch_available = True
 except ModuleNotFoundError:
     torch_available = False
-
-from typing import Callable, List, Optional, Union
-
-
-from ..individual import IndividualBase
 
 
 def gradient_based(

--- a/cgp/node.py
+++ b/cgp/node.py
@@ -1,7 +1,6 @@
 import math  # noqa: F401
 import re
-
-from typing import Callable, Dict, List, Tuple, Type, TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Dict, List, Tuple, Type
 
 from . import node_validation
 

--- a/cgp/node_input_output.py
+++ b/cgp/node_input_output.py
@@ -1,4 +1,4 @@
-from typing import List, TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from .node import Node
 

--- a/cgp/node_validation.py
+++ b/cgp/node_validation.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING, Type
+
 import numpy as np
 
 try:
@@ -15,16 +17,15 @@ try:
 except ModuleNotFoundError:
     torch_available = False
 
-from typing import Type, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .node import OperatorNode  # noqa: F401
     from .genome import Genome  # noqa: F401
+    from .node import OperatorNode  # noqa: F401
 
 
 def _create_genome(cls: Type["OperatorNode"]) -> "Genome":
     # delayed imports to avoid circular imports
-    from .genome import Genome, ID_INPUT_NODE, ID_OUTPUT_NODE, ID_NON_CODING_GENE
+    from .genome import ID_INPUT_NODE, ID_NON_CODING_GENE, ID_OUTPUT_NODE, Genome
 
     primitives = (cls,)
     genome = Genome(1, 1, 1, 1, 1, primitives)

--- a/cgp/population.py
+++ b/cgp/population.py
@@ -1,9 +1,9 @@
-import numpy as np
-
 from typing import List, Union
 
+import numpy as np
+
 from .genome import Genome
-from .individual import IndividualBase, IndividualSingleGenome, IndividualMultiGenome
+from .individual import IndividualBase, IndividualMultiGenome, IndividualSingleGenome
 
 
 class Population:

--- a/cgp/primitives.py
+++ b/cgp/primitives.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
-import numpy as np
-
 from typing import Iterator, Tuple, Type
+
+import numpy as np
 
 from .node import Node
 

--- a/cgp/utils.py
+++ b/cgp/utils.py
@@ -1,12 +1,12 @@
 import functools
 import hashlib
-import numpy as np
 import os
 import pickle
-
 from typing import Any, Callable, Dict, List, Tuple, Type, Union
 
-from .node import primitives_dict, Node
+import numpy as np
+
+from .node import Node, primitives_dict
 
 
 def __check_cache_consistency(fn: str, func: Callable[..., float]) -> None:
@@ -53,11 +53,7 @@ def __store_new_cache_entry(
 ) -> None:
     with open(fn, "ab") as f:
 
-        result = {
-            "args": args,
-            "kwargs": kwargs,
-            "return_value": return_value,
-        }
+        result = {"args": args, "kwargs": kwargs, "return_value": return_value}
 
         pickle.dump({key: result}, f)
 

--- a/examples/example_caching.py
+++ b/examples/example_caching.py
@@ -8,8 +8,9 @@ compare the runtime of this script when you first call it vs. the
 second time and when you comment out the decorator on
 `inner_objective`."""
 
-import numpy as np
 import time
+
+import numpy as np
 
 import cgp
 

--- a/examples/example_differential_evo_regression.py
+++ b/examples/example_differential_evo_regression.py
@@ -21,6 +21,7 @@ References:
 """
 
 import functools
+
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.constants
@@ -89,12 +90,7 @@ genome_params = {
     "primitives": (cgp.Add, cgp.Sub, cgp.Mul, cgp.Parameter),
 }
 
-ea_params = {
-    "n_offsprings": 4,
-    "tournament_size": 1,
-    "n_processes": 1,
-    "k_local_search": 2,
-}
+ea_params = {"n_offsprings": 4, "tournament_size": 1, "n_processes": 1, "k_local_search": 2}
 
 evolve_params = {"max_generations": 2000, "min_fitness": 0.0}
 

--- a/examples/example_evo_regression.py
+++ b/examples/example_evo_regression.py
@@ -8,10 +8,11 @@ two regression tasks.
 
 
 import functools
+import warnings
+
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.constants
-import warnings
 
 import cgp
 

--- a/examples/example_mountain_car.py
+++ b/examples/example_mountain_car.py
@@ -14,6 +14,13 @@ Install the OpenAI Gym package: `pip install gym`
 
 
 import functools
+import warnings
+
+import matplotlib.pyplot as plt
+import numpy as np
+import sympy
+
+import cgp
 
 try:
     import gym
@@ -22,12 +29,6 @@ except ImportError:
         "Failed to import the OpenAI Gym package. Please install it via `pip install gym`."
     )
 
-import matplotlib.pyplot as plt
-import numpy as np
-import sympy
-import warnings
-
-import cgp
 
 # %%
 # For more flexibility in the evolved expressions, we define two

--- a/examples/example_parametrized_nodes.py
+++ b/examples/example_parametrized_nodes.py
@@ -11,13 +11,13 @@ which produces a scaled and shifted version of the sum of its inputs.
 
 import functools
 import math
+
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.constants
 import torch
 
 import cgp
-
 
 # %%
 # We first define a new node that adds two inputs then scales and
@@ -138,9 +138,7 @@ def recording_callback(pop):
 
 obj = functools.partial(objective, seed=population_params["seed"])
 
-cgp.evolve(
-    pop, obj, ea, **evolve_params, print_progress=True, callback=recording_callback,
-)
+cgp.evolve(pop, obj, ea, **evolve_params, print_progress=True, callback=recording_callback)
 
 # %%
 # After the evolutionary search has ended, we print the expression

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -8,6 +8,7 @@ pytest ~= 5.4.1
 mypy ~= 0.770
 black ~= 19.10b0
 flake8 ~= 3.7.9
+isort ~=5.2.2
 # doc requirements
 sphinx ~=3.1.2
 recommonmark~=0.6.0

--- a/test/test_cartesian_graph.py
+++ b/test/test_cartesian_graph.py
@@ -1,9 +1,10 @@
 import itertools
+
 import numpy as np
 import pytest
 
 import cgp
-from cgp.genome import ID_INPUT_NODE, ID_OUTPUT_NODE, ID_NON_CODING_GENE
+from cgp.genome import ID_INPUT_NODE, ID_NON_CODING_GENE, ID_OUTPUT_NODE
 
 
 def test_direct_input_output():

--- a/test/test_ea_mu_plus_lambda.py
+++ b/test/test_ea_mu_plus_lambda.py
@@ -1,4 +1,5 @@
 import functools
+
 import numpy as np
 import pytest
 
@@ -84,7 +85,7 @@ def test_offspring_individuals_are_assigned_correct_parent_indices(
 
 
 def test_local_search_is_only_applied_to_best_k_individuals(
-    population_params, local_search_params, ea_params,
+    population_params, local_search_params, ea_params
 ):
 
     torch = pytest.importorskip("torch")

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -1,10 +1,11 @@
 import math
+
 import numpy as np
 import pytest
 
 import cgp
-from cgp.genome import ID_INPUT_NODE, ID_OUTPUT_NODE, ID_NON_CODING_GENE
 from cgp.cartesian_graph import CartesianGraph
+from cgp.genome import ID_INPUT_NODE, ID_NON_CODING_GENE, ID_OUTPUT_NODE
 
 
 def test_check_dna_consistency():

--- a/test/test_hl_api.py
+++ b/test/test_hl_api.py
@@ -1,7 +1,8 @@
 import functools
+import time
+
 import numpy as np
 import pytest
-import time
 
 import cgp
 

--- a/test/test_individual.py
+++ b/test/test_individual.py
@@ -1,14 +1,13 @@
 import math
-import numpy as np
 import pickle
 from collections import namedtuple
 
+import numpy as np
 import pytest
 
 import cgp
-from cgp import IndividualSingleGenome, IndividualMultiGenome
-from cgp.genome import ID_INPUT_NODE, ID_OUTPUT_NODE, ID_NON_CODING_GENE
-
+from cgp import IndividualMultiGenome, IndividualSingleGenome
+from cgp.genome import ID_INPUT_NODE, ID_NON_CODING_GENE, ID_OUTPUT_NODE
 
 TestParams = namedtuple("TestParams", ["genome_params", "primitives", "dna", "target_function"])
 params_list = [

--- a/test/test_local_search.py
+++ b/test/test_local_search.py
@@ -1,7 +1,7 @@
 import pytest
 
 import cgp
-from cgp.genome import ID_INPUT_NODE, ID_OUTPUT_NODE, ID_NON_CODING_GENE
+from cgp.genome import ID_INPUT_NODE, ID_NON_CODING_GENE, ID_OUTPUT_NODE
 
 
 def test_gradient_based_step_towards_maximum():

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 import cgp
-from cgp.genome import ID_INPUT_NODE, ID_OUTPUT_NODE, ID_NON_CODING_GENE
+from cgp.genome import ID_INPUT_NODE, ID_NON_CODING_GENE, ID_OUTPUT_NODE
 
 
 def test_inputs_are_cut_to_match_arity():
@@ -287,14 +287,7 @@ def test_parameter():
     primitives = (cgp.Parameter,)
     genome = cgp.Genome(**genome_params, primitives=primitives)
     # f(x) = c
-    genome.dna = [
-        ID_INPUT_NODE,
-        ID_NON_CODING_GENE,
-        0,
-        0,
-        ID_OUTPUT_NODE,
-        1,
-    ]
+    genome.dna = [ID_INPUT_NODE, ID_NON_CODING_GENE, 0, 0, ID_OUTPUT_NODE, 1]
 
     x = [1.0]
     y_target = [1.0]  # by default the output value of the Parameter node is 1.0
@@ -318,14 +311,7 @@ def test_parameter_w_custom_initial_value():
     primitives = (CustomParameter,)
     genome = cgp.Genome(**genome_params, primitives=primitives)
     # f(x) = c
-    genome.dna = [
-        ID_INPUT_NODE,
-        ID_NON_CODING_GENE,
-        0,
-        0,
-        ID_OUTPUT_NODE,
-        1,
-    ]
+    genome.dna = [ID_INPUT_NODE, ID_NON_CODING_GENE, 0, 0, ID_OUTPUT_NODE, 1]
 
     x = [1.0]
     y_target = [initial_value]
@@ -389,14 +375,7 @@ def test_parameter_w_random_initial_value(rng_seed):
     primitives = (CustomParameter,)
     genome = cgp.Genome(**genome_params, primitives=primitives)
     # f(x) = c
-    genome.dna = [
-        ID_INPUT_NODE,
-        ID_NON_CODING_GENE,
-        0,
-        0,
-        ID_OUTPUT_NODE,
-        1,
-    ]
+    genome.dna = [ID_INPUT_NODE, ID_NON_CODING_GENE, 0, 0, ID_OUTPUT_NODE, 1]
     f = cgp.CartesianGraph(genome).to_func()
     y = f([0.0])[0]
 
@@ -427,14 +406,7 @@ def test_multiple_parameters_per_node():
     primitives = (DoubleParameter,)
     genome = cgp.Genome(**genome_params, primitives=primitives)
     # f(x) = p + q
-    genome.dna = [
-        ID_INPUT_NODE,
-        ID_NON_CODING_GENE,
-        0,
-        0,
-        ID_OUTPUT_NODE,
-        1,
-    ]
+    genome.dna = [ID_INPUT_NODE, ID_NON_CODING_GENE, 0, 0, ID_OUTPUT_NODE, 1]
     f = cgp.CartesianGraph(genome).to_func()
     y = f([0.0])[0]
 

--- a/test/test_population.py
+++ b/test/test_population.py
@@ -1,6 +1,7 @@
 import copy
-import pytest
+
 import numpy as np
+import pytest
 
 import cgp
 

--- a/test/test_primitives.py
+++ b/test/test_primitives.py
@@ -1,4 +1,5 @@
 import dataclasses
+
 import pytest
 
 import cgp

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,9 +1,10 @@
 import concurrent.futures
 import functools
-import numpy as np
-import pytest
 import tempfile
 import time
+
+import numpy as np
+import pytest
 
 import cgp
 


### PR DESCRIPTION
This PR introduces [isort](https://github.com/timothycrosley/isort) to our tools ensuring common coding standards and uniform layout across the library.

`isort` sorts import statements in a particular, reproducible order, namely like this: `FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER`

This PR:
- applies `isort` to all files in the library, testsuite, and examples. Therefore there are a lot of changes in many files, but they are just about formatting, mostly to the imports. Some changes are introduced by `black` as well (trailing commas in function definitions). I am not sure why this happens.
- adds a config file for `isort`
- adds `isort` to the required `dev` libraries
- adds `isort` as an additional check to the CI.
- adds my pre-commit configuration file to the repository. This will make it easier for other contributors to install the pre-commit hooks using that config file.