### PR TITLE
Make sure user-set attributes of individuals are copied to offspring

### DIFF
--- a/docs/documentation/population_individual.rst
+++ b/docs/documentation/population_individual.rst
@@ -35,6 +35,21 @@ There are two types of individuals:
 These classes are thin wrappers around the `Genome` (see :meth:`cgp.Genome`) and
 the `CartesianGraph` (see :meth:`cgp.CartesianGraph`) classes.
 
+Any custom properties of individuals that are set within the objective function are copied to their offspring.
+This, for example, allows recording of variables used during fitness evaluation:
+
+.. code-block:: python
+
+  def objective(individual):
+      individual.fitness = 1.0
+      individual.my_custom_attribute = 123
+      return individual
+
+  history = {}
+  history["my_custom_attribute"] = []
+  def recording_callback(pop):
+      history["my_custom_attribute"].append(pop.champion.my_custom_attribute)
+
 ------
 Genome
 ------

--- a/test/test_individual.py
+++ b/test/test_individual.py
@@ -307,3 +307,16 @@ def test_individual_randomize_genome(individual_type, rng_seed):
 
     individual.randomize_genome(rng)
     assert dna_old != _unpack_genome(individual, individual_type)
+
+
+@pytest.mark.parametrize("individual_type", ["SingleGenome", "MultiGenome"])
+def test_clone_copies_user_defined_attributes(individual_type, genome_params, rng):
+    genome = cgp.Genome(**genome_params)
+    genome.randomize(rng)
+    ind = _create_individual(genome, individual_type=individual_type)
+    my_attribute = "this is a custom attribute"
+    ind.my_attribute = my_attribute
+    ind_clone = ind.clone()
+
+    assert ind.my_attribute == my_attribute
+    assert ind_clone.my_attribute == my_attribute


### PR DESCRIPTION
In some cases it would be nice to record some historical information within the objective function. The easiest approach would be to create a objective-function closure, similar to the history callback, and let the objective directly write to the corresponding recording object. This works well will a single process, but since parallel processes are running in different interpreter instances, it does not work with multiprocessing (at least i didn't get it to work).

Here I'm making a suggestion based on discussions with @HenrikMettler: the user can set (new) attributes of individuals within the objective which could then be subsequently recorded outside the parallel context, similar to recording, e.g., fitness values. To make this work we need to make sure offspring inherit all these custom attributes from their parents, since some offspring are never evaluated (for example due to mutation in silent regions) and hence never have this attribute set.

Please regard this only as a suggestion, I'm happy to hear about other solutions!