### PR TITLE
Shorten execution of examples in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,20 +33,25 @@ script:
   - isort --check-only cgp examples test
   - if [ "$DEP" = "[all]" -a $TRAVIS_PYTHON_VERSION = 3.8 ]; then
        pip install gym || exit 1;
-       make -C docs/ html || exit 1;
-       touch docs/_build/html/.nojekyll || exit 1;
+       make -C docs/ html-examples-short || exit 1;
     fi
   - pytest --cov=cgp
 after_success:
   - coveralls
 deploy:
-  provider: pages:git
-  skip_cleanup: true
-  verbose: true
-  token: $GITHUB_TOKEN
-  edge: true
-  local_dir: ./docs/_build/html/
-  keep_history: true
-  on:
-    python: 3.8
-    condition: $DEP = "[all]"
+  - provider: script
+    script: bash docs/deploy.sh
+    on:
+      python: 3.8
+      condition: $DEP = "[all]"
+    edge: true
+  - provider: pages:git
+    skip_cleanup: true
+    verbose: true
+    token: $GITHUB_TOKEN
+    edge: true
+    local_dir: ./docs/_build/html/
+    keep_history: true
+    on:
+      python: 3.8
+      condition: $DEP = "[all]"

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -27,3 +27,8 @@ html-noplot:
 	$(SPHINXBUILD) -D plot_gallery=0 -b html $(SOURCEDIR) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+
+html-examples-short:
+	$(SPHINXBUILD) -D reset_argv=1 -b html $(SOURCEDIR) $(BUILDDIR)/html
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,15 +6,17 @@
 
 # -- Path setup --------------------------------------------------------------
 
+import inspect
+import os
+import sys
+
+import msmb_theme
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import cgp
-import inspect
-import os
-import sys
-import msmb_theme
 
 sys.path.insert(0, os.path.join(os.path.abspath("."), "../"))
 
@@ -66,6 +68,18 @@ html_static_path = ["_static"]
 
 # -- Options for Sphinx Gallery ---------------------------------------------
 
+
+class ExampleCLIArgs:
+    def __repr__(self):
+        return "ExampleCLIArgs"
+
+    def __call__(self, sphinx_gallery_conf, script_vars):
+        if "example_caching.py" in script_vars["src_file"]:
+            return []
+        else:
+            return ["--max-generations", "10"]
+
+
 sphinx_gallery_conf = {
     "filename_pattern": "/*.py",
     "examples_dirs": "../examples",  # path to your example scripts
@@ -73,6 +87,11 @@ sphinx_gallery_conf = {
     "matplotlib_animations": True,
     "image_scrapers": ("matplotlib",),
 }
+
+for arg in sys.argv:
+    if "reset_argv" in arg:
+        sphinx_gallery_conf["reset_argv"] = ExampleCLIArgs()
+        break
 
 
 def linkcode_resolve(domain, info):

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -1,0 +1,3 @@
+make -C docs/ clean
+make -C docs/ html
+touch docs/_build/html/.nojekyll

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -14,5 +14,5 @@ sphinx ~=3.1.2
 recommonmark~=0.6.0
 msmb_theme~=1.2.0
 sphinx-rtd-theme~=0.5.0
-sphinx-gallery~=0.7.0
+sphinx-gallery@git+https://git@github.com/sphinx-gallery/sphinx-gallery@387900334ace5c0bf74e9e90aad1e8d2a54e6f17
 pillow~=7.2.0


### PR DESCRIPTION
This PR solves #208  by doing:

- Add new mode for making docs with shortened example runs
- Add class to set command line args in sphinx configuration
- Shorten example runs in Travis CI and add docs building in deployment phase
- Use specific commit of sphinx-gallery that includes the new option to specify CLI arguments (https://github.com/sphinx-gallery/sphinx-gallery/commit/387900334ace5c0bf74e9e90aad1e8d2a54e6f17)