### PR TITLE
Fix bug in Node.__repr__

### DIFF
--- a/cgp/cartesian_graph.py
+++ b/cgp/cartesian_graph.py
@@ -173,7 +173,7 @@ class CartesianGraph:
                 continue
             active_nodes_by_hidden_column_idx[self._hidden_column_idx(node.idx)].add(node)
 
-            for i in node.inputs:
+            for i in node.input_nodes:
                 nodes_to_process.append(self._nodes[i])
 
         return active_nodes_by_hidden_column_idx

--- a/cgp/node.py
+++ b/cgp/node.py
@@ -33,7 +33,7 @@ class Node:
 
     _arity: int
     _active: bool = False
-    _inputs: List[int]
+    _input_nodes: List[int]
     _output: float
     _output_str: str
     _idx: int
@@ -49,7 +49,7 @@ class Node:
             List of integers specifying the input nodes to this node.
         """
         self._idx = idx
-        self._inputs = inputs[: self._arity]
+        self._input_nodes = inputs[: self._arity]
 
         assert idx not in inputs
 
@@ -66,11 +66,11 @@ class Node:
 
     @property
     def max_arity(self) -> int:
-        return len(self._inputs)
+        return len(self._input_nodes)
 
     @property
-    def inputs(self) -> List[int]:
-        return self._inputs
+    def input_nodes(self) -> List[int]:
+        return self._input_nodes
 
     @property
     def idx(self) -> int:
@@ -79,7 +79,7 @@ class Node:
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(idx: {self.idx}, active: {self._active}, "
-            f"arity: {self._arity}, inputs {self._inputs}, output {self._output})"
+            f"arity: {self._arity}, input_nodes {self._input_nodes}"
         )
 
     def pretty_str(self, n: int) -> str:
@@ -102,7 +102,7 @@ class Node:
             if self._arity > 0:
                 s += "("
                 for i in range(self._arity):
-                    s += f"{self._inputs[i]:02d},"
+                    s += f"{self._input_nodes[i]:02d},"
                 s = s[:-1]
                 s += ")"
                 for i in range(self.max_arity - self._arity):
@@ -218,7 +218,7 @@ class OperatorNode(Node):
 
         for input_name in self._input_names:
             idx = self._extract_index_from_input_name(input_name)
-            output_str = output_str.replace(input_name, f"{graph[self._inputs[idx]].output}")
+            output_str = output_str.replace(input_name, f"{graph[self._input_nodes[idx]].output}")
 
         exec_str = f"self._output = {output_str}"
         exec(exec_str)
@@ -226,7 +226,7 @@ class OperatorNode(Node):
     def _replace_input_names(self, output_str: str, graph: "CartesianGraph") -> str:
         for input_name in self._input_names:
             idx = self._extract_index_from_input_name(input_name)
-            output_str = output_str.replace(input_name, graph[self._inputs[idx]].output_str)
+            output_str = output_str.replace(input_name, graph[self._input_nodes[idx]].output_str)
         return output_str
 
     def _replace_parameter_names(self, output_str: str, graph: "CartesianGraph") -> str:

--- a/cgp/node_input_output.py
+++ b/cgp/node_input_output.py
@@ -12,8 +12,8 @@ class InputNode(Node):
 
     _arity = 0
 
-    def __init__(self, idx: int, inputs: List[int]) -> None:
-        super().__init__(idx, inputs)
+    def __init__(self, idx: int, input_nodes: List[int]) -> None:
+        super().__init__(idx, input_nodes)
 
     def __call__(self, x: List[float], graph: "CartesianGraph") -> None:
         assert False
@@ -37,14 +37,14 @@ class OutputNode(Node):
 
     _arity = 1
 
-    def __init__(self, idx: int, inputs: List[int]) -> None:
-        super().__init__(idx, inputs)
+    def __init__(self, idx: int, input_nodes: List[int]) -> None:
+        super().__init__(idx, input_nodes)
 
     def __call__(self, x: List[float], graph: "CartesianGraph") -> None:
-        self._output = graph[self._inputs[0]].output
+        self._output = graph[self._input_nodes[0]].output
 
     def format_output_str(self, graph: "CartesianGraph") -> None:
-        self._output_str = f"{graph[self._inputs[0]].output_str}"
+        self._output_str = f"{graph[self._input_nodes[0]].output_str}"
 
     def format_output_str_numpy(self, graph: "CartesianGraph") -> None:
         self.format_output_str(graph)

--- a/test/test_cartesian_graph.py
+++ b/test/test_cartesian_graph.py
@@ -602,3 +602,10 @@ def test_pretty_str_with_unequal_inputs_rows_outputs():
 02 * InputNode          \t                        \t07 * OutputNode (04)    \t
 """
     assert graph.pretty_str() == expected_pretty_str
+
+
+def test_repr(rng, genome_params):
+    genome = cgp.Genome(**genome_params)
+    genome.randomize(rng)
+    # Assert that the CartesianGraph.__repr__ doesn't raise an error
+    str(cgp.CartesianGraph(genome))

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -12,16 +12,16 @@ def test_inputs_are_cut_to_match_arity():
 
     """
     idx = 0
-    inputs = [1, 2, 3, 4]
+    input_nodes = [1, 2, 3, 4]
 
-    node = cgp.ConstantFloat(idx, inputs)
-    assert node.inputs == []
+    node = cgp.ConstantFloat(idx, input_nodes)
+    assert node.input_nodes == []
 
-    node = cgp.node_input_output.OutputNode(idx, inputs)
-    assert node.inputs == inputs[:1]
+    node = cgp.node_input_output.OutputNode(idx, input_nodes)
+    assert node.input_nodes == input_nodes[:1]
 
-    node = cgp.Add(idx, inputs)
-    assert node.inputs == inputs[:2]
+    node = cgp.Add(idx, input_nodes)
+    assert node.input_nodes == input_nodes[:2]
 
 
 def _test_graph_call_and_to_x_compilations(
@@ -448,3 +448,23 @@ def test_raise_broken_def_sympy_output():
             _arity = 2
             _def_output = "x_0 + x_1"
             _def_sympy_output = "x_0 +/ x_1"
+
+
+def test_repr():
+    idx = 0
+    input_nodes = [1, 2, 3, 4]
+
+    # Test example of OperatorNode with arity 0
+    node = cgp.ConstantFloat(idx, input_nodes)
+    node_repr = str(node)
+    assert node_repr == "ConstantFloat(idx: 0, active: False, arity: 0, input_nodes []"
+
+    # Test OutputNode
+    node = cgp.node_input_output.OutputNode(idx, input_nodes)
+    node_repr = str(node)
+    assert node_repr == "OutputNode(idx: 0, active: False, arity: 1, input_nodes [1]"
+
+    # Test example of OperatorNode with arity 2
+    node = cgp.Add(idx, input_nodes)
+    node_repr = str(node)
+    assert node_repr == "Add(idx: 0, active: False, arity: 2, input_nodes [1, 2]"


### PR DESCRIPTION
This PR fixes #232 by following the suggestions of @jakobj in the ticket:

- Remove _output from repr string of Node class
- Rename _inputs to _input_nodes for better clarity
- Add test of CartesianGraph.__repr__ function
- Add test for __repr__ of 3 example nodes