### PR TITLE
Limiting fitness evaluations

### DIFF
--- a/cgp/ea/mu_plus_lambda.py
+++ b/cgp/ea/mu_plus_lambda.py
@@ -52,7 +52,7 @@ class MuPlusLambda:
         self.local_search = local_search
         self.k_local_search = k_local_search
 
-        self.n_objective_calls = 0
+        self.n_objective_calls: int = 0
 
     def initialize_fitness_parents(
         self, pop: Population, objective: Callable[[IndividualBase], IndividualBase]
@@ -104,8 +104,6 @@ class MuPlusLambda:
         # population instead of the other way around
         combined = offsprings + pop.parents
 
-        self.update_n_objective_calls(combined)
-
         # we follow a two-step process for selection of new parents:
         # we first determine the fitness for all individuals, then, if
         # applicable, we apply local search to the k_local_search
@@ -150,6 +148,8 @@ class MuPlusLambda:
         self, combined: List[IndividualBase], objective: Callable[[IndividualBase], IndividualBase]
     ) -> List[IndividualBase]:
 
+        self.update_n_objective_calls(combined)
+
         # computes fitness on all individuals, objective functions
         # should return immediately if fitness is not None
         if self.n_processes == 1:
@@ -193,5 +193,5 @@ class MuPlusLambda:
          i.e., for which the objective function will be evaluated.
         """
         for individual in combined:
-            if individual.fitness is not None:
+            if individual.fitness is None:
                 self.n_objective_calls += 1

--- a/cgp/ea/mu_plus_lambda.py
+++ b/cgp/ea/mu_plus_lambda.py
@@ -52,6 +52,8 @@ class MuPlusLambda:
         self.local_search = local_search
         self.k_local_search = k_local_search
 
+        self.n_objective_calls = 0
+
     def initialize_fitness_parents(
         self, pop: Population, objective: Callable[[IndividualBase], IndividualBase]
     ) -> None:
@@ -102,6 +104,8 @@ class MuPlusLambda:
         # population instead of the other way around
         combined = offsprings + pop.parents
 
+        self.update_n_objective_calls(combined)
+
         # we follow a two-step process for selection of new parents:
         # we first determine the fitness for all individuals, then, if
         # applicable, we apply local search to the k_local_search
@@ -145,6 +149,7 @@ class MuPlusLambda:
     def _compute_fitness(
         self, combined: List[IndividualBase], objective: Callable[[IndividualBase], IndividualBase]
     ) -> List[IndividualBase]:
+
         # computes fitness on all individuals, objective functions
         # should return immediately if fitness is not None
         if self.n_processes == 1:
@@ -182,3 +187,11 @@ class MuPlusLambda:
 
         """
         return combined[:n_parents]
+
+    def update_n_objective_calls(self, combined: List[IndividualBase]) -> None:
+        """Increase n_objective_calls by the number of individuals with fitness=None,
+         i.e., for which the objective function will be evaluated.
+        """
+        for individual in combined:
+            if individual.fitness is not None:
+                self.n_objective_calls += 1

--- a/test/test_hl_api.py
+++ b/test/test_hl_api.py
@@ -135,6 +135,24 @@ def test_evolve_two_expressions(population_params, ea_params):
     assert abs(pop.champion.fitness) == pytest.approx(0.0)
 
 
+def test_finite_max_generations_or_max_objective_calls(
+    population_params, genome_params, ea_params
+):
+    def objective(individual):
+        individual.fitness = float(individual.idx)
+        return individual
+
+    pop = cgp.Population(**population_params, genome_params=genome_params)
+    ea = cgp.ea.MuPlusLambda(**ea_params)
+    evolve_params = {
+        "max_generations": np.inf,
+        "min_fitness": 0,
+        "max_objective_calls": np.inf,
+    }
+    with pytest.raises(ValueError):
+        cgp.evolve(pop, objective, ea, **evolve_params)
+
+
 def _objective_speedup_parallel_evolve(individual):
 
     time.sleep(0.25)


### PR DESCRIPTION
This PR draft is a suggestion for a solution to #224 
It works by counting the calls of the objective function using a decorator (as suggested eg: https://stackoverflow.com/questions/21716940/is-there-a-way-to-track-the-number-of-times-a-function-is-called). I am not sure if this is a reasonable approach, mainly two things bother me: 

- the subtraction if fitness is not reevalutated (necessary since we don't want to count those)
- if a caching decorator is used for the inner objective, the counts of the objective function calls might not correspond to full function evaluations anymore