### PR TITLE
Dev/genome reorder

### DIFF
--- a/cgp/ea/mu_plus_lambda.py
+++ b/cgp/ea/mu_plus_lambda.py
@@ -25,6 +25,7 @@ class MuPlusLambda:
         n_processes: int = 1,
         local_search: Callable[[IndividualBase], None] = lambda combined: None,
         k_local_search: Union[int, None] = None,
+        reorder_genome: bool = False,
     ):
         """Init function
 
@@ -44,6 +45,13 @@ class MuPlusLambda:
         k_local_search : int
             Number of individuals in the whole population (parents +
             offsprings) to apply local search to.
+       reorder_genome: bool, optional
+            Whether genome reordering should be applied.
+            Reorder shuffles the genotype of an individual without changing its phenotype,
+            thereby contributing to neutral drift through the genotypic search space.
+            If True, reorder is applied to each parents genome at every generation
+            before creating offsprings.
+            Defaults to True.
         """
         self.n_offsprings = n_offsprings
 
@@ -51,6 +59,7 @@ class MuPlusLambda:
         self.n_processes = n_processes
         self.local_search = local_search
         self.k_local_search = k_local_search
+        self.reorder_genome = reorder_genome
 
     def initialize_fitness_parents(
         self, pop: Population, objective: Callable[[IndividualBase], IndividualBase]
@@ -71,7 +80,7 @@ class MuPlusLambda:
         pop._parents = self._compute_fitness(pop.parents, objective)
 
     def step(
-        self, pop: Population, objective: Callable[[IndividualBase], IndividualBase]
+        self, pop: Population, objective: Callable[[IndividualBase], IndividualBase],
     ) -> Population:
         """Perform one step in the evolution.
 
@@ -89,6 +98,10 @@ class MuPlusLambda:
         Population
             Modified population with new parents.
         """
+
+        if self.reorder_genome:
+            pop.reorder_genome()
+
         offsprings = self._create_new_offspring_generation(pop)
 
         # we want to prefer offsprings with the same fitness as their

--- a/cgp/hl_api.py
+++ b/cgp/hl_api.py
@@ -45,6 +45,7 @@ def evolve(
         parallel evaluation of the objective is supported. Currently
         not implemented. Defaults to 1.
 
+
     Returns
     -------
     None

--- a/cgp/individual.py
+++ b/cgp/individual.py
@@ -61,6 +61,9 @@ class IndividualBase:
     def randomize_genome(self, rng):
         raise NotImplementedError()
 
+    def reorder_genome(self, rng):
+        raise NotImplementedError()
+
     def to_func(self):
         raise NotImplementedError()
 
@@ -83,6 +86,10 @@ class IndividualBase:
     @staticmethod
     def _randomize_genome(genome: Genome, rng: np.random.RandomState) -> None:
         genome.randomize(rng)
+
+    @staticmethod
+    def _reorder_genome(genome: Genome, rng: np.random.RandomState) -> None:
+        genome.reorder(rng)
 
     @staticmethod
     def _to_func(genome: Genome) -> Callable[[List[float]], List[float]]:
@@ -137,6 +144,9 @@ class IndividualSingleGenome(IndividualBase):
     def randomize_genome(self, rng: np.random.RandomState) -> None:
         self._randomize_genome(self.genome, rng)
 
+    def reorder_genome(self, rng: np.random.RandomState) -> None:
+        self._reorder_genome(self.genome, rng)
+
     def to_func(self) -> Callable[[List[float]], List[float]]:
         return self._to_func(self.genome)
 
@@ -185,6 +195,10 @@ class IndividualMultiGenome(IndividualBase):
     def randomize_genome(self, rng: np.random.RandomState) -> None:
         for g in self.genome:
             self._randomize_genome(g, rng)
+
+    def reorder_genome(self, rng: np.random.RandomState) -> None:
+        for g in self.genome:
+            self._reorder_genome(g, rng)
 
     def to_func(self) -> List[Callable[[List[float]], List[float]]]:
         return [self._to_func(g) for g in self.genome]

--- a/cgp/population.py
+++ b/cgp/population.py
@@ -133,3 +133,13 @@ class Population:
             List of fitness values for all parents.
         """
         return [ind.fitness for ind in self._parents]
+
+    def reorder_genome(self) -> None:
+        """ Reorders the genome for all parents in the population
+
+        Returns
+        ---------
+        None
+        """
+        for parent in self.parents:
+            parent.reorder_genome(self.rng)

--- a/examples/example_reorder.py
+++ b/examples/example_reorder.py
@@ -1,0 +1,161 @@
+"""
+Example for evolutionary regression with genome reordering
+===========================================================
+
+Example demonstrating the effect of genome reordering.
+
+References
+-----------
+Goldman B.W., Punch W.F. (2014): Analysis of Cartesian Genetic Programming’s
+Evolutionary Mechanisms
+DOI: 10.1109/TEVC.2014.2324539
+"""
+
+# The docopt str is added explicitly to ensure compatibility with
+# sphinx-gallery.
+docopt_str = """
+   Usage:
+     example_reorder.py [--max-generations=<N>]
+
+   Options:
+     -h --help
+     --max-generations=<N>  Maximum number of generations [default: 300]
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+import scipy.constants
+from docopt import docopt
+
+import cgp
+
+args = docopt(docopt_str)
+
+# %%
+# We first define a target function.
+
+
+def f_target(x):
+    return x[0] ** 2 + 1.0
+
+
+# %%
+# Then we define the objective function for the evolution. It uses
+# the mean-squared error between the output of the expression
+# represented by a given individual and the target function evaluated
+# on a set of random points.
+
+
+def objective(individual):
+    if individual.fitness is not None:
+        return individual
+
+    n_function_evaluations = 1000
+
+    np.random.seed(1234)
+
+    f = individual.to_func()
+    loss = 0
+    for x in np.random.uniform(-4, 4, n_function_evaluations):
+        # the callable returned from `to_func` accepts and returns
+        # lists; accordingly we need to pack the argument and unpack
+        # the return value
+        y = f([x])[0]
+        loss += (f_target([x]) - y) ** 2
+
+    individual.fitness = -loss / n_function_evaluations
+
+    return individual
+
+
+# %%
+# Next, we set up the evolutionary search. We first define the
+# parameters for the population, the genome of individuals, and two
+# evolutionary algorithms without (default) and with genome reordering.
+
+
+population_params = {"n_parents": 1, "mutation_rate": 0.03, "seed": 818821}
+
+genome_params = {
+    "n_inputs": 1,
+    "n_outputs": 1,
+    "n_columns": 12,
+    "n_rows": 1,
+    "levels_back": None,
+    "primitives": (cgp.Add, cgp.Sub, cgp.Mul, cgp.ConstantFloat),
+}
+
+ea_params = {"n_offsprings": 4, "tournament_size": 2, "n_processes": 2}
+ea_params_with_reorder = {
+    "n_offsprings": 4,
+    "tournament_size": 2,
+    "n_processes": 2,
+    "reorder_genome": True,
+}
+
+evolve_params = {"max_generations": int(args["--max-generations"]), "min_fitness": 0.0}
+
+# %%
+# We create two populations that will be evolved
+pop = cgp.Population(**population_params, genome_params=genome_params)
+pop_with_reorder = cgp.Population(**population_params, genome_params=genome_params)
+
+# %%
+# and two instances of the (mu + lambda) evolutionary algorithm
+ea = cgp.ea.MuPlusLambda(**ea_params)
+ea_with_reorder = cgp.ea.MuPlusLambda(**ea_params_with_reorder)
+
+# %%
+# We define two callbacks for recording of fitness over generations
+history = {}
+history["fitness_champion"] = []
+
+
+def recording_callback(pop):
+    history["fitness_champion"].append(pop.champion.fitness)
+
+
+history_with_reorder = {}
+history_with_reorder["fitness_champion"] = []
+
+
+def recording_callback_with_reorder(pop):
+    history_with_reorder["fitness_champion"].append(pop.champion.fitness)
+
+
+# %%
+# and finally perform the evolution of the two populations
+cgp.evolve(
+    pop, objective, ea, **evolve_params, print_progress=True, callback=recording_callback,
+)
+
+cgp.evolve(
+    pop_with_reorder,
+    objective,
+    ea_with_reorder,
+    **evolve_params,
+    print_progress=True,
+    callback=recording_callback_with_reorder,
+)
+
+
+# %%
+# After finishing the evolution, we plot the evolution of the fittest individual
+# with and without genome reordering
+
+
+width = 9.0
+fig = plt.figure(1, figsize=[width, width / scipy.constants.golden])
+
+plt.plot(history["fitness_champion"], label="Champion")
+plt.plot(history_with_reorder["fitness_champion"], label="Champion with reorder")
+
+plt.xlabel("Generation")
+plt.ylabel("Fitness")
+plt.legend(["Champion", "Champion with reorder"])
+
+plt.yscale("symlog")
+plt.ylim(-1.0e2, 0.1)
+plt.axhline(0.0, color="0.7")
+
+fig.savefig("example_reorder.pdf", dpi=300)


### PR DESCRIPTION
Implements a first solution to #225 
Reorders the nodes in the parents genome(s) before creating offspring, without violating any node dependencies, as suggested in Goldman 2015. Works only with `levels_back = n_columns` and `n_rows = 1` since possible issue with limitations in levels_back and more than 1 row are not accounted for. 
Currently I did not add a new example for this functionality but changed `levels_back = n_columns` in `example_minimal.py` and set the boolean for doing reorder to true. 
Testing currently only covers repeated application of reorder on two examples genomes, while asserting no changes in the resulting sympy expression. 