### PR TITLE
Catch type error in simplification

### DIFF
--- a/cgp/cartesian_graph.py
+++ b/cgp/cartesian_graph.py
@@ -412,7 +412,10 @@ class _C(torch.nn.Module):
 
         if not simplify:
             return sympy_exprs
-        else:  # simplify expression if desired
+        else:  # simplify expression if desired and possible
             for i, expr in enumerate(sympy_exprs):
-                sympy_exprs[i] = expr.simplify()
+                try:
+                    sympy_exprs[i] = expr.simplify()
+                except TypeError:
+                    RuntimeWarning(f"SymPy could not simplify expression: {expr}")
             return sympy_exprs


### PR DESCRIPTION
As discussed in #231 we should catch errors thrown by sympy when calling `expr.simplify`. 
When implementing this PR I noticed that the option of the boolean `simplify = False` is never used. Maybe we could remove it altogether?