### PR TITLE
Bump version number to 0.2.0 to prepare for release

### DIFF
--- a/cgp/__init__.py
+++ b/cgp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.0dev"
+__version__ = "0.2.0"
 __maintainer__ = "Jakob Jordan, Maximilian Schmidt"
 __author__ = "Happy Algorithms League"
 __license__ = "GPLv3"


### PR DESCRIPTION
This PR sets the version to 0.2.0 to complete the milestone and prepare for the release.