### PR TITLE
Implement multiversion building for the docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ branches:
   only:
     - master
     - sphinx_doc/multi_version
+git:
+  depth: false
 jobs:
   exclude:
   - python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
 branches:
   only:
     - master
+    - sphinx_doc/multi_version
 jobs:
   exclude:
   - python: "3.6"
@@ -27,6 +28,7 @@ install:
   - pip install -e .$DEP
   - pip install pytest-cov coveralls
 script:
+  - git fetch --all --tags
   - black --check .
   - flake8 --config=.flake8 .
   - mypy cgp
@@ -44,6 +46,7 @@ deploy:
     on:
       python: 3.8
       condition: $DEP = "[all]"
+      tags: true
     edge: true
   - provider: pages:git
     skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_install:
   - source activate myenv
   - pip install --upgrade pip
 install:
+  - git fetch --all --tags
   - pip install -e .$DEP
   - pip install pytest-cov coveralls
 script:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line, and also
 # from the environment for the first two.
 SPHINXOPTS    ?=
-SPHINXBUILD   ?= sphinx-build
+SPHINXBUILD   ?= sphinx-multiversion
 SOURCEDIR     = .
 BUILDDIR      = _build
 
@@ -17,18 +17,18 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 clean:
 	rm -rf $(BUILDDIR)/*
 	rm -rf auto_examples/
 
 html-noplot:
-	$(SPHINXBUILD) -D plot_gallery=0 -b html $(SOURCEDIR) $(BUILDDIR)/html
+	$(SPHINXBUILD) -D plot_gallery=0 $(SOURCEDIR) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 html-examples-short:
-	$(SPHINXBUILD) -D reset_argv=1 -b html $(SOURCEDIR) $(BUILDDIR)/html
+	$(SPHINXBUILD) -D reset_argv=1 $(SOURCEDIR) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,7 @@ import inspect
 import os
 import sys
 
-import msmb_theme
+import sphinx_rtd_theme
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -40,7 +40,9 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.linkcode",
     "recommonmark",
+    "sphinx_rtd_theme",
     "sphinx_gallery.gen_gallery",
+    "sphinx_multiversion",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -57,9 +59,17 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "msmb_theme"
+html_theme = "sphinx_rtd_theme"
 
-html_theme_path = [msmb_theme.get_html_theme_path()]
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
+
+# Configuration for multiversion builds
+smv_branch_whitelist = "master"  # Only build master branch
+smv_remote_whitelist = None
+smv_tag_whitelist = "0.2.0"  # Only release 0.2.0 has a sphinx documentation
+smv_released_pattern = r".*"  # Tags only
+smv_outputdir_format = "{ref.name}"  # Use the branch/tag name
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -12,7 +12,7 @@ isort ~=5.2.2
 # doc requirements
 sphinx ~=3.1.2
 recommonmark~=0.6.0
-msmb_theme~=1.2.0
 sphinx-rtd-theme~=0.5.0
 sphinx-gallery~=0.8.0
+sphinx-multiversion~=0.2.4
 pillow~=7.2.0


### PR DESCRIPTION
Use sphinx-multiversion instead of sphinx-build
Configure multiversion builds in docs conf file
Use RTD theme because it supports multiversion, remove msmb_theme
Add sphinx-multiversion to requirements

Closes #251 .

You can test this PR locally by running 
```bash
cd docs
make html
```
and observing the outcome. There should be a pulldown menu on the bottom left that enables you to switch between `master` and the `0.2.0` release.