### PR TITLE
Provide support for hurdles

### DIFF
--- a/cgp/population.py
+++ b/cgp/population.py
@@ -64,7 +64,6 @@ class Population:
         """
 
         def key(ind: IndividualBase) -> float:
-            assert isinstance(ind.fitness, float)
             return ind.fitness
 
         return max(self._parents, key=key)
@@ -101,7 +100,7 @@ class Population:
         if isinstance(self._genome_params, dict):
             genome: Genome = Genome(**self._genome_params)
             individual_s = IndividualSingleGenome(
-                fitness=None, genome=genome
+                genome=genome
             )  # type: IndividualBase # indicates to mypy that
             # individual_s is instance of a child class of
             # IndividualBase
@@ -109,7 +108,7 @@ class Population:
         else:
             genomes: List[Genome] = [Genome(**gd) for gd in self._genome_params]
             individual_m = IndividualMultiGenome(
-                fitness=None, genome=genomes
+                genome=genomes
             )  # type: IndividualBase # indicates to mypy that
             # individual_m is an instance of a child class of
             # IndividualBase

--- a/examples/example_caching.py
+++ b/examples/example_caching.py
@@ -53,7 +53,7 @@ def inner_objective(expr):
 
 
 def objective(individual):
-    if individual.fitness is not None:
+    if not individual.fitness_is_None():
         return individual
 
     individual.fitness = -inner_objective(individual.to_sympy())

--- a/examples/example_differential_evo_regression.py
+++ b/examples/example_differential_evo_regression.py
@@ -79,7 +79,7 @@ def inner_objective(f, seed):
 def objective(individual, seed):
     """Objective function of the regression task."""
 
-    if individual.fitness is not None:
+    if not individual.fitness_is_None():
         return individual
 
     f = individual.to_torch()

--- a/examples/example_evo_regression.py
+++ b/examples/example_evo_regression.py
@@ -65,7 +65,7 @@ def objective(individual, target_function, seed):
     Individual
         Modified individual with updated fitness value.
     """
-    if individual.fitness is not None:
+    if not individual.fitness_is_None():
         return individual
 
     n_function_evaluations = 1000

--- a/examples/example_fec_caching.py
+++ b/examples/example_fec_caching.py
@@ -65,7 +65,7 @@ def inner_objective(ind):
 
 
 def objective(individual):
-    if individual.fitness is not None:
+    if not individual.fitness_is_None():
         return individual
 
     individual.fitness = -inner_objective(individual)

--- a/examples/example_mountain_car.py
+++ b/examples/example_mountain_car.py
@@ -106,7 +106,7 @@ def inner_objective(f, seed, n_runs_per_individual, n_total_steps, *, render):
 
 def objective(ind, seed, n_runs_per_individual, n_total_steps):
 
-    if ind.fitness is not None:
+    if not ind.fitness_is_None():
         return ind
 
     f = ind.to_func()

--- a/examples/example_multi_genome.py
+++ b/examples/example_multi_genome.py
@@ -46,7 +46,7 @@ def f_target(x):
 
 
 def objective(individual):
-    if individual.fitness is not None:
+    if not individual.fitness_is_None():
         return individual
 
     n_function_evaluations = 1000

--- a/examples/example_parametrized_nodes.py
+++ b/examples/example_parametrized_nodes.py
@@ -85,7 +85,7 @@ def inner_objective(f, seed):
 
 
 def objective(individual, seed):
-    if individual.fitness is not None:
+    if not individual.fitness_is_None():
         return individual
 
     f = individual.to_torch()

--- a/examples/example_piecewise_target_function.py
+++ b/examples/example_piecewise_target_function.py
@@ -55,7 +55,7 @@ def objective(individual, rng):
     Individual
         Modified individual with updated fitness value.
     """
-    if individual.fitness is not None:
+    if not individual.fitness_is_None():
         return individual
 
     n_function_evaluations = 1000

--- a/examples/example_reorder.py
+++ b/examples/example_reorder.py
@@ -47,7 +47,7 @@ def f_target(x):
 
 
 def objective(individual):
-    if individual.fitness is not None:
+    if not individual.fitness_is_None():
         return individual
 
     n_function_evaluations = 1000

--- a/test/test_hl_api.py
+++ b/test/test_hl_api.py
@@ -9,7 +9,7 @@ import cgp
 
 def _objective_test_population(individual, rng_seed):
 
-    if individual.fitness is not None:
+    if not individual.fitness_is_None():
         return individual
 
     np.random.seed(rng_seed)
@@ -77,7 +77,7 @@ def test_evolve_two_expressions(population_params, ea_params):
 
     def _objective(individual):
 
-        if individual.fitness is not None:
+        if not individual.fitness_is_None():
             return individual
 
         def f0(x):

--- a/test/test_individual.py
+++ b/test/test_individual.py
@@ -50,9 +50,15 @@ def _create_genome(genome_params, primitives, dna):
 
 def _create_individual(genome, fitness=None, individual_type="SingleGenome"):
     if individual_type == "SingleGenome":
-        return IndividualSingleGenome(fitness, genome)
+        ind = IndividualSingleGenome(genome)
+        if fitness is not None:
+            ind.fitness = fitness
+        return ind
     elif individual_type == "MultiGenome":
-        return IndividualMultiGenome(fitness, [genome])
+        ind = IndividualMultiGenome([genome])
+        if fitness is not None:
+            ind.fitness = fitness
+        return ind
     else:
         raise NotImplementedError("Unknown individual type.")
 
@@ -250,9 +256,9 @@ def test_update_parameters_from_torch_class_resets_fitness(individual_type):
     f_opt = _unpack_evaluation(f, individual_type=individual_type)
     f_opt._p1.data[0] = math.pi
 
-    assert individual.fitness is not None
+    assert not individual.fitness_is_None()
     individual.update_parameters_from_torch_class(f)
-    assert individual.fitness is None
+    assert individual.fitness_is_None()
 
     g = _unpack_evaluation(individual.to_func(), individual_type)
     x = 2.0
@@ -286,9 +292,9 @@ def test_update_parameters_from_torch_class_does_not_reset_fitness_for_unused_pa
 
     f = individual.to_torch()
 
-    assert individual.fitness is not None
+    assert not individual.fitness_is_None()
     individual.update_parameters_from_torch_class(f)
-    assert individual.fitness is not None
+    assert not individual.fitness_is_None()
 
     g = _unpack_evaluation(individual.to_func(), individual_type)
     x = 2.0

--- a/test/test_local_search.py
+++ b/test/test_local_search.py
@@ -11,7 +11,7 @@ def test_gradient_based_step_towards_maximum():
     genome = cgp.Genome(1, 1, 1, 1, 1, primitives)
     # f(x) = c
     genome.dna = [ID_INPUT_NODE, ID_NON_CODING_GENE, 0, 0, ID_OUTPUT_NODE, 1]
-    ind = cgp.individual.IndividualSingleGenome(None, genome)
+    ind = cgp.individual.IndividualSingleGenome(genome)
 
     def objective(f):
         x_dummy = torch.zeros((1, 1), dtype=torch.double)  # not used
@@ -42,7 +42,7 @@ def test_gradient_based_step_towards_maximum_multi_genome():
     # f(x) = c
     genome.dna = [ID_INPUT_NODE, ID_NON_CODING_GENE, 0, 0, ID_OUTPUT_NODE, 1]
     genome2 = genome.clone()
-    ind = cgp.individual.IndividualMultiGenome(None, [genome, genome2])
+    ind = cgp.individual.IndividualMultiGenome([genome, genome2])
 
     def objective(f):
         x_dummy = torch.zeros((1, 1), dtype=torch.double)  # not used


### PR DESCRIPTION
This PR suggests an implementation that allows users to specify hurdles. Hurdles effectively implement early stopping for poorly performing individuals. The implementation allows users to pass lists of objectives to the EA/hl API and to define the "hurdle percentile" as a parameter of the EA for each of the objectives. Only individuals achieving fitness in the upper "hurdle percentile" of the _unique_ fitness values of the _whole_ population (parents + offspring) for the first objective are evaluated on the second objective, and so on.

An example is provided as extension of the minimal example (docstrings are yet to be adapted), where the performance difference is quite visible when considering a large number of function evaluations (28s w/o hurdles, 11s with hurdles on an i5-8350U).

Please review in particular with respect to usability and transparency of the implementation.

closes #255