### PR TITLE
Implement local search that does not require differential objectives -- evolution strategies

### DIFF
--- a/cgp/local_search/__init__.py
+++ b/cgp/local_search/__init__.py
@@ -1,1 +1,2 @@
+from .evolution_strategies import EvolutionStrategies
 from .gradient_based import gradient_based

--- a/cgp/local_search/evolution_strategies.py
+++ b/cgp/local_search/evolution_strategies.py
@@ -1,0 +1,207 @@
+import collections
+import functools
+import math
+from typing import TYPE_CHECKING, Callable, Dict, List, Tuple, Union
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from ..individual import IndividualBase
+
+
+class EvolutionStrategies:
+    def __init__(
+        self,
+        objective: Callable[["IndividualBase"], float],
+        seed: int,
+        *,
+        learning_rate_mu: float = 1.0,
+        learning_rate_sigma: Union[None, float] = None,
+        population_size: Union[None, int] = None,
+        max_steps: int = 10,
+        min_sigma: float = 1e-9,
+        fitness_shaping: bool = True,
+        mirrored_sampling: bool = True,
+    ) -> None:
+        """Evolution strategies using the natural gradient of multinormal
+        search distributions in natural coordinates.
+
+        Standard deviation of the search distribution for each
+        parameter is stored per individual. Offspring may use the
+        values of their parents if the number of used parameters has
+        not changed. Does not consider covariances between parameters.
+
+        Implementation and default values following Wierstra et
+        al. (2014). Natural evolution strategies. Journal of Machine
+        Learning Research, 15(1), 949-980.
+
+        Parameters
+        ----------
+        individual : Individual
+            Individual for which to perform local search.
+        objective : Callable[[Callable[[np.ndarray[float]], np.ndarray[float]]], float]
+            Objective function used for the local search. Needs to accept
+            an numpy-compatible function as first argument (e.g., from
+            IndividualBase.to_numpy()) and return a float representing the
+            fitness of the individual.
+        seed : int
+            Seed for internal random number generator.
+        learning_rate_mu : float, optional
+            Learning rate for mean of search distribution.
+            Defaults to 1.0.
+        learning_rate_sigma : float, optional
+            Learning rate for standard deviation of search
+            distribution. Defaults to (3 + log(dim)) / (5.0 *
+            sqrt(dim)), where dim is the dimension of the search space.
+        population_size : int, optional
+            Number of samples evaluated per step. Defaults to 4
+            + floor(3 * log(dim))), where dim is the dimension of the
+            search space..
+        max_steps : int, optional
+            Maximal number of steps. Defaults to 10.
+        min_sigma : float, optional
+            Minimal value for standard deviation of search
+            distribution. Defaults to 1e-9.
+        fitness_shaping : bool, optional
+            Whether to use fitness shaping. Defaults to True.
+        mirrored_sampling : bool, optional
+            Whether to use mirrored sampling. WARNING: Doubles the number
+            of samples per step. Defaults to True.
+
+        """
+        self.objective = objective
+        self.seed = seed
+        self.learning_rate_mu = learning_rate_mu
+        self.learning_rate_sigma = learning_rate_sigma
+        self.population_size = population_size
+        self.max_steps = max_steps
+        self.min_sigma = min_sigma
+        self.fitness_shaping = fitness_shaping
+        self.mirrored_sampling = mirrored_sampling
+
+        self.sigma: Dict[int, Dict[str, np.ndarray[float]]] = collections.defaultdict(dict)
+
+    def __call__(self, ind: "IndividualBase") -> None:
+
+        rng = np.random.RandomState(self.seed)
+
+        mu: np.ndarray[float]
+        params_names: List[str]
+        mu, params_names = ind.parameters_to_numpy_array(only_active_nodes=True)
+
+        sigma: np.ndarray[float] = self._load_sigma(ind, mu, params_names)
+
+        if len(mu) > 0:
+            if self.learning_rate_sigma is None:
+                learning_rate_sigma = (3 + math.log(len(mu))) / (5.0 * math.sqrt(len(mu)))
+            else:
+                learning_rate_sigma = self.learning_rate_sigma
+
+            if self.population_size is None:
+                population_size = 4 + int(math.floor(3 * math.log(len(mu))))
+            else:
+                population_size = self.population_size
+
+            obj: Callable[[np.ndarray[float]], float] = functools.partial(
+                self._objective_wrapper, ind=ind, params_names=params_names
+            )
+
+            for step in range(self.max_steps):
+
+                s: np.ndarray[float]
+                z: np.ndarray[float]
+                s, z = self._sample_s_and_z(mu, sigma, population_size, rng)
+
+                fitness: np.ndarray[float] = np.fromiter(map(obj, z), np.float)
+
+                s, z, utility = self._determine_utility(s, z, fitness)
+
+                mu, sigma = self._update_parameters_of_search_distribution(
+                    s, utility, learning_rate_sigma, mu, sigma
+                )
+
+                sigma[sigma < self.min_sigma] = self.min_sigma
+
+            ind.update_parameters_from_numpy_array(mu, params_names)
+
+        # WARNING: should not be indented as all individuals should
+        # store their sigma whether they have changed or not to allow
+        # propagation over many generations of the outer optimization
+        assert isinstance(ind.idx, int)
+        self._store_sigma(ind.idx, sigma, params_names)
+
+    def _load_sigma(
+        self, ind: "IndividualBase", mu: "np.ndarray[float]", params_names: List[str]
+    ) -> "np.ndarray[float]":
+        sigma: List[float] = []
+        for i, p in enumerate(params_names):
+            if ind.idx in self.sigma and p in self.sigma[ind.idx]:
+                sigma.append(self.sigma[ind.idx][p])
+            elif ind.parent_idx in self.sigma and p in self.sigma[ind.parent_idx]:
+                sigma.append(self.sigma[ind.parent_idx][p])
+            else:
+                sigma.append(0.05 * np.abs(mu[i]))
+
+        return np.array(sigma)
+
+    def _store_sigma(self, idx: int, sigma: "np.ndarray[float]", params_names: List[str]) -> None:
+        for i, p in enumerate(params_names):
+            self.sigma[idx][p] = sigma[i]
+
+    def _sample_s_and_z(
+        self, mu: np.ndarray, sigma: np.ndarray, population_size: int, rng: "np.random.RandomState"
+    ) -> Tuple["np.ndarray[float]", "np.ndarray[float]"]:
+        s: np.ndarray[float] = rng.normal(0, 1, size=(population_size, *mu.shape))
+        z: np.ndarray[float] = mu + sigma * s
+
+        if self.mirrored_sampling:
+            z = np.vstack([z, mu - sigma * s])
+            s = np.vstack([s, -s])
+
+        return s, z
+
+    def _objective_wrapper(
+        self, z: "np.ndarray[float]", *, ind: "IndividualBase", params_names: List[str]
+    ) -> float:
+        new_ind: IndividualBase = ind.clone()
+        new_ind.update_parameters_from_numpy_array(z, params_names)
+        return self.objective(new_ind)
+
+    def _determine_utility(
+        self, s: "np.ndarray[float]", z: "np.ndarray[float]", fitness: "np.ndarray[float]",
+    ) -> Tuple["np.ndarray[float]", "np.ndarray[float]", "np.ndarray[float]"]:
+        if self.fitness_shaping:
+            order, utility = self._utility_function(fitness)
+            s = s[order]
+            z = z[order]
+        else:
+            utility = fitness
+
+        return s, z, utility
+
+    def _utility_function(
+        self, fitness: np.ndarray
+    ) -> Tuple["np.ndarray[int]", "np.ndarray[float]"]:
+        n: int = len(fitness)
+        order: np.ndarray[float] = np.argsort(fitness)[::-1]
+
+        fitness = fitness[order]
+
+        utility: np.ndarray[float] = [
+            np.max([0, math.log((n / 2) + 1)]) - math.log(k + 1) for k in range(n)
+        ]
+        utility = utility / np.sum(utility) - 1.0 / n
+
+        return order, utility
+
+    def _update_parameters_of_search_distribution(
+        self,
+        s: np.ndarray,
+        utility: "np.ndarray[float]",
+        learning_rate_sigma,
+        mu: np.ndarray,
+        sigma: np.ndarray,
+    ) -> Tuple["np.ndarray[float]", "np.ndarray[float]"]:
+        mu += self.learning_rate_mu * sigma * np.dot(utility, s)
+        sigma *= np.exp(learning_rate_sigma / 2.0 * np.dot(utility, s ** 2 - 1))
+        return mu, sigma

--- a/examples/example_local_search_evolution_strategies.py
+++ b/examples/example_local_search_evolution_strategies.py
@@ -1,0 +1,180 @@
+"""
+Example for evolutionary regression with local search via evolution strategies
+==============================================================================
+
+Example demonstrating the use of Cartesian genetic programming for a
+regression task that involves numeric constants. Local search via
+evolution strategies is used to determine numeric leaf values of the
+graph.
+"""
+
+# The docopt str is added explicitly to ensure compatibility with
+# sphinx-gallery.
+docopt_str = """
+  Usage:
+    example_local_search_evolution_strategies.py [--max-generations=<N>]
+
+  Options:
+    -h --help
+    --max-generations=<N>  Maximum number of generations [default: 500]
+
+"""
+
+import functools
+
+import matplotlib.pyplot as plt
+import numpy as np
+import scipy.constants
+from docopt import docopt
+
+import cgp
+
+args = docopt(docopt_str)
+
+# %%
+# We first define the target function. Note that this function contains
+# numeric values which are initially not available as constants to the search.
+
+
+def f_target(x):
+    return np.e * x[:, 0] ** 2 + 1.0 + np.pi
+
+
+# %%
+# Then we define the objective function for the evolution. It consists
+# of an inner objective which accepts a NumPy-compatible function as
+# its first argument and returns the mean-squared error between the
+# expression represented by a given individual and the target function
+# evaluated on a set of random points. This inner objective is used by
+# the local search to determine appropriate values for Parameter node
+# and the actual objective function to update the fitness of the
+# individual.
+
+
+def inner_objective(ind, seed):
+    """Return a loss for the numpy-compatible function f. Used for
+    calculating the fitness of each individual and for the local
+    search of numeric leaf values.
+
+    """
+
+    f = ind.to_numpy()
+    rng = np.random.RandomState(seed)
+    batch_size = 500
+    x = rng.uniform(-5, 5, size=(batch_size, 1))
+    y = f(x)
+    return -np.mean((f_target(x) - y[:, 0]) ** 2)
+
+
+def objective(individual, seed):
+    """Objective function of the regression task."""
+
+    if not individual.fitness_is_None():
+        return individual
+
+    individual.fitness = inner_objective(individual, seed)
+
+    return individual
+
+
+# %%
+# Next, we define the parameters for the population, the genome of
+# individuals, the evolutionary algorithm, and the local search.
+
+
+population_params = {"n_parents": 1, "seed": 818821}
+
+genome_params = {
+    "n_inputs": 1,
+    "n_outputs": 1,
+    "n_columns": 36,
+    "n_rows": 1,
+    "levels_back": None,
+    "primitives": (cgp.Add, cgp.Sub, cgp.Mul, cgp.Parameter),
+}
+
+ea_params = {
+    "n_offsprings": 4,
+    "mutation_rate": 0.05,
+    "tournament_size": 1,
+    "n_processes": 1,
+    "k_local_search": 2,
+}
+
+evolve_params = {"max_generations": int(args["--max-generations"]), "min_fitness": 0.0}
+
+# restrict the number of steps in the local search; since parameter
+# values are propagated from parents to offsprings, parameter values
+# may be iteratively improved across generations despite the small
+# number of steps per generation
+local_search_params = {"max_steps": 5}
+
+# %%
+# We then create a Population instance and instantiate the local search
+# and evolutionary algorithm.
+
+pop = cgp.Population(**population_params, genome_params=genome_params)
+
+# define the function for local search; an instance of the
+# EvolutionStrategies can be called with an individual as an argument
+# for which the local search is performed
+local_search = cgp.local_search.EvolutionStrategies(
+    objective=functools.partial(inner_objective, seed=population_params["seed"] + 1),
+    seed=population_params["seed"] + 2,
+    **local_search_params,
+)
+
+ea = cgp.ea.MuPlusLambda(**ea_params, local_search=local_search)
+
+# %%
+#  We define a recording callback closure for bookkeeping of the progression of the evolution.
+
+
+history = {}
+history["champion"] = []
+history["fitness_parents"] = []
+
+
+def recording_callback(pop):
+    history["champion"].append(pop.champion)
+    history["fitness_parents"].append(pop.fitness_parents())
+
+
+obj = functools.partial(objective, seed=population_params["seed"] + 1)
+
+# %%
+# Finally, we call the `evolve` method to perform the evolutionary search.
+
+cgp.evolve(pop, obj, ea, **evolve_params, print_progress=True, callback=recording_callback)
+
+
+# %%
+# After finishing the evolution, we plot the result and log the final
+# evolved expression.
+
+width = 9.0
+fig = plt.figure(figsize=(width, width / scipy.constants.golden))
+
+ax_fitness = fig.add_subplot(121)
+ax_fitness.set_xlabel("Generation")
+ax_fitness.set_ylabel("Fitness")
+ax_fitness.set_yscale("symlog")
+
+ax_function = fig.add_subplot(122)
+ax_function.set_ylabel(r"$f(x)$")
+ax_function.set_xlabel(r"$x$")
+
+
+print(f"Final expression {pop.champion.to_sympy()[0]} with fitness {pop.champion.fitness}")
+
+history_fitness = np.array(history["fitness_parents"])
+ax_fitness.plot(np.max(history_fitness, axis=1), label="Champion")
+ax_fitness.plot(np.mean(history_fitness, axis=1), label="Population mean")
+
+x = np.linspace(-5.0, 5, 100).reshape(-1, 1)
+f = pop.champion.to_func()
+y = [f(xi) for xi in x]
+ax_function.plot(x, f_target(x), lw=2, label="Target")
+ax_function.plot(x, y, lw=1, label="Target", marker="x")
+
+plt.savefig("example_local_search_evolution_strategies.pdf", dpi=300)

--- a/test/test_ls_evolution_strategies.py
+++ b/test/test_ls_evolution_strategies.py
@@ -1,0 +1,139 @@
+import numpy as np
+import pytest
+
+import cgp
+from cgp.genome import ID_INPUT_NODE, ID_NON_CODING_GENE, ID_OUTPUT_NODE
+
+
+def test_step_towards_maximum(rng_seed):
+    primitives = (cgp.Parameter,)
+    genome = cgp.Genome(1, 2, 2, 1, primitives)
+    # [f0(x), f1(x)] = [c1, c2]
+    genome.dna = [
+        ID_INPUT_NODE,
+        ID_NON_CODING_GENE,
+        0,
+        0,
+        0,
+        0,
+        ID_OUTPUT_NODE,
+        1,
+        ID_OUTPUT_NODE,
+        2,
+    ]
+    ind = cgp.individual.IndividualSingleGenome(genome)
+    ind.idx = 0
+
+    def objective(ind):
+        f = ind.to_numpy()
+        x_dummy = np.zeros((1, 1))  # input, not used
+        target_value = np.array([[1.0, 1.1]])
+        return -np.sum((f(x_dummy) - target_value) ** 2)
+
+    # test increase parameter value if too small
+    ind.genome._parameter_names_to_values["<p1>"] = 0.8
+    ind.genome._parameter_names_to_values["<p2>"] = 0.9
+    es = cgp.local_search.EvolutionStrategies(objective, rng_seed, max_steps=1)
+    es(ind)
+    assert ind.genome._parameter_names_to_values["<p1>"] > 0.8
+    assert ind.genome._parameter_names_to_values["<p2>"] > 0.9
+
+    # test decrease parameter value if too large
+    ind.genome._parameter_names_to_values["<p1>"] = 1.1
+    ind.genome._parameter_names_to_values["<p2>"] = 1.2
+    es = cgp.local_search.EvolutionStrategies(objective, rng_seed, max_steps=1)
+    es(ind)
+    assert ind.genome._parameter_names_to_values["<p1>"] < 1.1
+    assert ind.genome._parameter_names_to_values["<p2>"] < 1.2
+
+
+def _objective_convergence_to_maximum(ind):
+    f = ind.to_numpy()
+    x_dummy = np.zeros((1, 1))  # input, not used
+    target_value = np.array([[1.0, 1.1]])
+    return -np.sum((f(x_dummy) - target_value) ** 2)
+
+
+def test_convergence_to_maximum(rng_seed):
+    primitives = (cgp.Parameter,)
+    genome = cgp.Genome(1, 2, 2, 1, primitives)
+    # [f0(x), f1(x)] = [c1, c2]
+    genome.dna = [
+        ID_INPUT_NODE,
+        ID_NON_CODING_GENE,
+        0,
+        0,
+        0,
+        0,
+        ID_OUTPUT_NODE,
+        1,
+        ID_OUTPUT_NODE,
+        2,
+    ]
+    ind = cgp.individual.IndividualSingleGenome(genome)
+    ind.idx = 0
+
+    # single process
+    ind.genome._parameter_names_to_values["<p1>"] = 0.85
+    ind.genome._parameter_names_to_values["<p2>"] = 0.95
+    es = cgp.local_search.EvolutionStrategies(
+        _objective_convergence_to_maximum, rng_seed, max_steps=60
+    )
+    es(ind)
+    assert ind.genome._parameter_names_to_values["<p1>"] == pytest.approx(1.0)
+    assert ind.genome._parameter_names_to_values["<p2>"] == pytest.approx(1.1)
+
+
+def test_step_towards_maximum_multi_genome(rng_seed):
+    primitives = (cgp.Parameter,)
+    genome = cgp.Genome(1, 2, 2, 1, primitives)
+    # [f0(x), f1(x)] = [c1, c2]
+    genome.dna = [
+        ID_INPUT_NODE,
+        ID_NON_CODING_GENE,
+        0,
+        0,
+        0,
+        0,
+        ID_OUTPUT_NODE,
+        1,
+        ID_OUTPUT_NODE,
+        2,
+    ]
+    genome2 = genome.clone()
+    ind = cgp.individual.IndividualMultiGenome([genome, genome2])
+    ind.idx = 0
+
+    def objective(ind):
+        f = ind.to_numpy()
+        x_dummy = np.zeros((1, 1))  # input, not used
+        target_value = np.array([[1.0, 1.1]])
+        return -np.sum((f[0](x_dummy) - target_value) ** 2) - np.sum(
+            (f[1](x_dummy) - target_value) ** 2
+        )
+
+    # test increase parameter value if too small first genome,
+    # decrease parameter value if too large for second genome
+    ind.genome[0]._parameter_names_to_values["<p1>"] = 0.8
+    ind.genome[0]._parameter_names_to_values["<p2>"] = 0.9
+    ind.genome[1]._parameter_names_to_values["<p1>"] = 1.1
+    ind.genome[1]._parameter_names_to_values["<p2>"] = 1.2
+    es = cgp.local_search.EvolutionStrategies(objective, rng_seed, max_steps=2)
+    es(ind)
+    assert ind.genome[0]._parameter_names_to_values["<p1>"] > 0.8
+    assert ind.genome[0]._parameter_names_to_values["<p2>"] > 0.9
+    assert ind.genome[1]._parameter_names_to_values["<p1>"] < 1.1
+    assert ind.genome[1]._parameter_names_to_values["<p2>"] < 1.2
+
+    # test decrease parameter value if too large first genome,
+    # increase parameter value if too small for second genome
+    ind.genome[0]._parameter_names_to_values["<p1>"] = 1.1
+    ind.genome[0]._parameter_names_to_values["<p2>"] = 1.2
+    ind.genome[1]._parameter_names_to_values["<p1>"] = 0.8
+    ind.genome[1]._parameter_names_to_values["<p2>"] = 0.9
+    es = cgp.local_search.EvolutionStrategies(objective, rng_seed, max_steps=2)
+    es(ind)
+    assert ind.genome[0]._parameter_names_to_values["<p1>"] < 1.1
+    assert ind.genome[0]._parameter_names_to_values["<p2>"] < 1.2
+    assert ind.genome[1]._parameter_names_to_values["<p1>"] > 0.8
+    assert ind.genome[1]._parameter_names_to_values["<p2>"] > 0.9


### PR DESCRIPTION
This PR implements separable natural evolution strategies (https://jmlr.org/papers/volume15/wierstra14a/wierstra14a.pdf) as a local search algorithm. Tests and an example are provided.

To get everything working smoothly, I needed to make sure outcomes of the local search are only accepted if they indeed increase the fitness of the respective individual (https://github.com/Happy-Algorithms-League/hal-cgp/compare/master...jakobj:enh/local-search-es?expand=1#diff-e76e9c33f502310da4d066b5ee5bd4e34e475e453c754ed908f19f34e4afef19R140 ff). Thereby closes #215.

Please review in particular with respect to ease of use and maintainability.

closes #146 