### PR TITLE
Improved caching decorator

### DIFF
--- a/examples/example_fec_caching.py
+++ b/examples/example_fec_caching.py
@@ -10,6 +10,7 @@ second time and when you comment out the decorator on
 
 """
 
+import multiprocessing as mp
 import time
 
 import numpy as np
@@ -42,6 +43,7 @@ def f_target(x):
     fec_min_value=-10.0,
     fec_max_value=10.0,
     fec_batch_size=5,
+    file_lock=mp.Lock(),
 )
 def inner_objective(ind):
     """The caching decorator uses the return values generated from
@@ -80,7 +82,7 @@ def objective(individual):
 
 params = {
     "population_params": {"n_parents": 10, "mutation_rate": 0.05, "seed": 8188211},
-    "ea_params": {"n_offsprings": 10, "tournament_size": 1, "n_processes": 1},
+    "ea_params": {"n_offsprings": 10, "tournament_size": 1, "n_processes": 2},
     "genome_params": {
         "n_inputs": 1,
         "n_outputs": 1,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 # encoding: utf8
 import re
-from setuptools import setup
 from collections import defaultdict
+
+from setuptools import setup
 
 
 def _cut_version_number_from_requirement(req):


### PR DESCRIPTION
This PR improves the disk cache decorator:
- the cache file consists of a single large dict containing (key: fitness) pairs; no need for a linear search through keys to find a match
- function arguments are now only stored for a single function call to support consistency checks; this avoid unnecessarily large cache files by storing arguments for each(!) result
- for using multiple processes, a lock is introduced to make sure they are reading from/writing to the cache file without interference