### PR TITLE
Rename input -> address for address genes in hidden/outp…

### DIFF
--- a/cgp/cartesian_graph.py
+++ b/cgp/cartesian_graph.py
@@ -181,7 +181,7 @@ class CartesianGraph:
                 continue
             active_nodes_by_hidden_column_idx[self._hidden_column_idx(node.idx)].add(node)
 
-            for i in node.input_nodes:
+            for i in node.addresses:
                 nodes_to_process.append(self._nodes[i])
 
         return active_nodes_by_hidden_column_idx

--- a/cgp/node_input_output.py
+++ b/cgp/node_input_output.py
@@ -41,10 +41,10 @@ class OutputNode(Node):
         super().__init__(idx, input_nodes)
 
     def __call__(self, x: List[float], graph: "CartesianGraph") -> None:
-        self._output = graph[self._input_nodes[0]].output
+        self._output = graph[self._addresses[0]].output
 
     def format_output_str(self, graph: "CartesianGraph") -> None:
-        self._output_str = f"{graph[self._input_nodes[0]].output_str}"
+        self._output_str = f"{graph[self._addresses[0]].output_str}"
 
     def format_output_str_numpy(self, graph: "CartesianGraph") -> None:
         self.format_output_str(graph)

--- a/cgp/primitives.py
+++ b/cgp/primitives.py
@@ -37,7 +37,7 @@ class Primitives:
 
     def _determine_max_arity(self) -> int:
 
-        arity = 1  # minimal possible arity (output nodes need one input)
+        arity = 1  # minimal possible arity (output nodes need one address)
 
         for p in self._primitives:
             if arity < p._arity:

--- a/examples/example_parametrized_nodes.py
+++ b/examples/example_parametrized_nodes.py
@@ -34,7 +34,7 @@ import cgp
 args = docopt(docopt_str)
 
 # %%
-# We first define a new node that adds two inputs then scales and
+# We first define a new node that adds the values of its two inputs then scales and
 # finally shifts the result. The scale ("w") and shift factors ("b")
 # are parameters that are adapted by local search. We need to define
 # the arity of the node, callables for the initial values for the

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -70,7 +70,7 @@ def test_check_dna_consistency():
             ID_NON_CODING_GENE,
         ]
 
-    # invalid input gene for input node
+    # invalid address gene for input node
     with pytest.raises(ValueError):
         genome.dna = [
             ID_INPUT_NODE,
@@ -104,7 +104,7 @@ def test_check_dna_consistency():
             ID_NON_CODING_GENE,
         ]
 
-    # invalid input gene for hidden node
+    # invalid address gene for hidden node
     with pytest.raises(ValueError):
         genome.dna = [
             ID_INPUT_NODE,
@@ -138,7 +138,7 @@ def test_check_dna_consistency():
             ID_NON_CODING_GENE,
         ]
 
-    # invalid input gene for input node
+    # invalid address gene for input node
     with pytest.raises(ValueError):
         genome.dna = [
             ID_INPUT_NODE,
@@ -155,7 +155,7 @@ def test_check_dna_consistency():
             ID_NON_CODING_GENE,
         ]
 
-    # invalid inactive input gene for output node
+    # invalid inactive address gene for output node
     with pytest.raises(ValueError):
         genome.dna = [
             ID_INPUT_NODE,
@@ -173,7 +173,7 @@ def test_check_dna_consistency():
         ]
 
 
-def test_permissible_inputs():
+def test_permissible_addresses():
     params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 4, "n_rows": 3, "levels_back": 2}
 
     primitives = (cgp.Add,)
@@ -190,7 +190,7 @@ def test_permissible_inputs():
     for input_idx in range(params["n_inputs"]):
         region_idx = input_idx
         with pytest.raises(AssertionError):
-            genome._permissible_inputs(region_idx)
+            genome._permissible_addresses(region_idx)
 
     expected_for_hidden = [
         [0, 1],
@@ -201,13 +201,13 @@ def test_permissible_inputs():
 
     for column_idx in range(params["n_columns"]):
         region_idx = params["n_inputs"] + params["n_rows"] * column_idx
-        assert expected_for_hidden[column_idx] == genome._permissible_inputs(region_idx)
+        assert expected_for_hidden[column_idx] == genome._permissible_addresses(region_idx)
 
     expected_for_output = list(range(params["n_inputs"] + params["n_rows"] * params["n_columns"]))
 
     for output_idx in range(params["n_outputs"]):
         region_idx = params["n_inputs"] + params["n_rows"] * params["n_columns"] + output_idx
-        assert expected_for_output == genome._permissible_inputs(region_idx)
+        assert expected_for_output == genome._permissible_addresses(region_idx)
 
 
 def test_region_iterators():
@@ -289,8 +289,8 @@ def test_catch_invalid_allele_in_inactive_region():
     primitives = (cgp.ConstantFloat,)
     genome = cgp.Genome(1, 1, 1, 1, 1, primitives)
 
-    # should raise error: ConstantFloat node has no inputs, but silent
-    # input gene should still specify valid input
+    # should raise error: ConstantFloat node has no addresses, but silent
+    # address gene should still specify valid address
     with pytest.raises(ValueError):
         genome.dna = [ID_INPUT_NODE, ID_NON_CODING_GENE, 0, ID_NON_CODING_GENE, ID_OUTPUT_NODE, 1]
 
@@ -359,7 +359,7 @@ def test_mutation_rate(rng_seed, mutation_rate):
     genome.randomize(rng)
 
     def count_n_immutable_genes(n_inputs, n_outputs, n_rows):
-        length_per_region = genome.primitives.max_arity + 1  # function gene + input gene addresses
+        length_per_region = genome.primitives.max_arity + 1  # function gene + address gene
         n_immutable_genes = n_inputs * length_per_region  # none of the input genes are mutable
         n_immutable_genes += n_outputs * (
             length_per_region - 1
@@ -367,7 +367,7 @@ def test_mutation_rate(rng_seed, mutation_rate):
         if n_inputs == 1:
             n_immutable_genes += (
                 n_rows * genome.primitives.max_arity
-            )  # input gene addresses in the first (hidden) column can't be mutated
+            )  # address gene in the first (hidden) column can't be mutated
             # if only one input node exists
         return n_immutable_genes
 
@@ -447,7 +447,7 @@ def test_only_silent_mutations(genome_params, mutation_rate, rng_seed):
     genome.dna = dna_fixed
     graph = CartesianGraph(genome)
     active_regions = graph.determine_active_regions()
-    length_per_region = genome.primitives.max_arity + 1  # function gene + input gene addresses
+    length_per_region = genome.primitives.max_arity + 1  # function gene + address gene
     gene_to_be_mutated_non_active = (
         3 * length_per_region
     )  # operator gene of 2nd hidden node, a silent node in this dna configuration
@@ -488,10 +488,10 @@ def test_permissible_values(genome_params):
     genome = cgp.Genome(n_inputs, n_outputs, n_columns, n_rows, levels_back, primitives)
 
     permissible_function_gene_values = np.arange(len(genome._primitives._primitives))
-    permissible_inputs_first_internal_column = np.array([0, 1])
-    permissible_inputs_second_internal_column = np.array([0, 1, 2, 3, 4])
-    permissible_inputs_third_internal_column = np.array([0, 1, 2, 3, 4, 5, 6, 7])
-    permissible_inputs_output_gene = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    permissible_addresses_first_internal_column = np.array([0, 1])
+    permissible_addresses_second_internal_column = np.array([0, 1, 2, 3, 4])
+    permissible_addresses_third_internal_column = np.array([0, 1, 2, 3, 4, 5, 6, 7])
+    permissible_addresses_output = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
     permissible_values_expected = [
         np.array(ID_INPUT_NODE),
@@ -501,34 +501,34 @@ def test_permissible_values(genome_params):
         np.array(ID_NON_CODING_GENE),
         np.array(ID_NON_CODING_GENE),
         permissible_function_gene_values,
-        permissible_inputs_first_internal_column,
-        permissible_inputs_first_internal_column,
+        permissible_addresses_first_internal_column,
+        permissible_addresses_first_internal_column,
         permissible_function_gene_values,
-        permissible_inputs_first_internal_column,
-        permissible_inputs_first_internal_column,
+        permissible_addresses_first_internal_column,
+        permissible_addresses_first_internal_column,
         permissible_function_gene_values,
-        permissible_inputs_first_internal_column,
-        permissible_inputs_first_internal_column,
+        permissible_addresses_first_internal_column,
+        permissible_addresses_first_internal_column,
         permissible_function_gene_values,
-        permissible_inputs_second_internal_column,
-        permissible_inputs_second_internal_column,
+        permissible_addresses_second_internal_column,
+        permissible_addresses_second_internal_column,
         permissible_function_gene_values,
-        permissible_inputs_second_internal_column,
-        permissible_inputs_second_internal_column,
+        permissible_addresses_second_internal_column,
+        permissible_addresses_second_internal_column,
         permissible_function_gene_values,
-        permissible_inputs_second_internal_column,
-        permissible_inputs_second_internal_column,
+        permissible_addresses_second_internal_column,
+        permissible_addresses_second_internal_column,
         permissible_function_gene_values,
-        permissible_inputs_third_internal_column,
-        permissible_inputs_third_internal_column,
+        permissible_addresses_third_internal_column,
+        permissible_addresses_third_internal_column,
         permissible_function_gene_values,
-        permissible_inputs_third_internal_column,
-        permissible_inputs_third_internal_column,
+        permissible_addresses_third_internal_column,
+        permissible_addresses_third_internal_column,
         permissible_function_gene_values,
-        permissible_inputs_third_internal_column,
-        permissible_inputs_third_internal_column,
+        permissible_addresses_third_internal_column,
+        permissible_addresses_third_internal_column,
         np.array(ID_OUTPUT_NODE),
-        permissible_inputs_output_gene,
+        permissible_addresses_output,
         np.array(ID_NON_CODING_GENE),
     ]
 

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -5,23 +5,23 @@ import cgp
 from cgp.genome import ID_INPUT_NODE, ID_NON_CODING_GENE, ID_OUTPUT_NODE
 
 
-def test_inputs_are_cut_to_match_arity():
-    """Test that even if a list of inputs longer than the node arity is
-    provided, Node.inputs only returns the initial <arity> inputs,
+def test_addresses_are_cut_to_match_arity():
+    """Test that even if a list of addresses longer than the node arity is
+    provided, Node.addresses only returns the initial <arity> addresses,
     ignoring the inactive genes.
 
     """
     idx = 0
-    input_nodes = [1, 2, 3, 4]
+    addresses = [1, 2, 3, 4]
 
-    node = cgp.ConstantFloat(idx, input_nodes)
-    assert node.input_nodes == []
+    node = cgp.ConstantFloat(idx, addresses)
+    assert node.addresses == []
 
-    node = cgp.node_input_output.OutputNode(idx, input_nodes)
-    assert node.input_nodes == input_nodes[:1]
+    node = cgp.node_input_output.OutputNode(idx, addresses)
+    assert node.addresses == addresses[:1]
 
-    node = cgp.Add(idx, input_nodes)
-    assert node.input_nodes == input_nodes[:2]
+    node = cgp.Add(idx, addresses)
+    assert node.addresses == addresses[:2]
 
 
 def _test_to_x_compilations(
@@ -467,9 +467,9 @@ def test_if_else_operator():
         ID_NON_CODING_GENE,
         ID_NON_CODING_GENE,
         0,  # function gene
-        0,  # first input gene is address of first input node
-        1,  # second input gene is address of second input node
-        2,  # third input gene is address of third input node
+        0,  # first gene is address of first input node
+        1,  # second gene is address of second input node
+        2,  # third gene is address of third input node
         ID_OUTPUT_NODE,
         3,
         ID_NON_CODING_GENE,
@@ -528,22 +528,22 @@ def test_raise_broken_def_sympy_output():
 
 def test_repr():
     idx = 0
-    input_nodes = [1, 2, 3, 4]
+    addresses = [1, 2, 3, 4]
 
     # Test example of OperatorNode with arity 0
-    node = cgp.ConstantFloat(idx, input_nodes)
+    node = cgp.ConstantFloat(idx, addresses)
     node_repr = str(node)
-    assert node_repr == "ConstantFloat(idx: 0, active: False, arity: 0, input_nodes []"
+    assert node_repr == "ConstantFloat(idx: 0, active: False, arity: 0, addresses of inputs []"
 
     # Test OutputNode
-    node = cgp.node_input_output.OutputNode(idx, input_nodes)
+    node = cgp.node_input_output.OutputNode(idx, addresses)
     node_repr = str(node)
-    assert node_repr == "OutputNode(idx: 0, active: False, arity: 1, input_nodes [1]"
+    assert node_repr == "OutputNode(idx: 0, active: False, arity: 1, addresses of inputs [1]"
 
     # Test example of OperatorNode with arity 2
-    node = cgp.Add(idx, input_nodes)
+    node = cgp.Add(idx, addresses)
     node_repr = str(node)
-    assert node_repr == "Add(idx: 0, active: False, arity: 2, input_nodes [1, 2]"
+    assert node_repr == "Add(idx: 0, active: False, arity: 2, addresses of inputs [1, 2]"
 
 
 def test_custom_node():


### PR DESCRIPTION
- renamed input_gene to address gene to describe the nodes from which hidden/output nodes read. Consistent with general literature. Closes #242. 