### PR TITLE
Check tournament_size <= n_parents in hl_api

### DIFF
--- a/cgp/ea/mu_plus_lambda.py
+++ b/cgp/ea/mu_plus_lambda.py
@@ -159,6 +159,10 @@ class MuPlusLambda:
     def _create_new_offspring_generation(self, pop: Population) -> List[IndividualBase]:
         # use tournament selection to randomly select individuals from
         # parent population
+
+        if self.tournament_size > pop.n_parents:
+            raise ValueError("tournament_size must be less or equal n_parents")
+
         offsprings: List[IndividualBase] = []
         while len(offsprings) < self.n_offsprings:
             tournament_pool = pop.rng.permutation(pop.parents)[: self.tournament_size]

--- a/cgp/ea/mu_plus_lambda.py
+++ b/cgp/ea/mu_plus_lambda.py
@@ -20,8 +20,8 @@ class MuPlusLambda:
     def __init__(
         self,
         n_offsprings: int,
-        tournament_size: int,
         *,
+        tournament_size: Union[None, int] = None,
         n_processes: int = 1,
         local_search: Callable[[IndividualBase], None] = lambda combined: None,
         k_local_search: Union[int, None] = None,
@@ -34,8 +34,8 @@ class MuPlusLambda:
         ----------
         n_offsprings : int
             Number of offspring in each iteration.
-        tournament_size : int
-            Tournament size in each iteration.
+        tournament_size : int, optional
+            Tournament size in each iteration. Defaults to the number of parents in the population
         n_processes : int, optional
             Number of parallel processes to be used. If greater than 1,
             parallel evaluation of the objective is supported. Defaults to 1.
@@ -159,6 +159,9 @@ class MuPlusLambda:
     def _create_new_offspring_generation(self, pop: Population) -> List[IndividualBase]:
         # use tournament selection to randomly select individuals from
         # parent population
+
+        if self.tournament_size is None:
+            self.tournament_size = pop.n_parents
 
         if self.tournament_size > pop.n_parents:
             raise ValueError("tournament_size must be less or equal n_parents")

--- a/examples/example_hurdles.py
+++ b/examples/example_hurdles.py
@@ -127,7 +127,6 @@ genome_params = {
 # the (n+1)th objective by a list of numbers between 0 and 1.
 ea_params = {
     "n_offsprings": 4,
-    "tournament_size": 2,
     "n_processes": 1,
     "hurdle_percentile": [0.5, 0.0],
 }

--- a/examples/example_minimal.py
+++ b/examples/example_minimal.py
@@ -81,7 +81,7 @@ genome_params = {
     "primitives": (cgp.Add, cgp.Sub, cgp.Mul, cgp.ConstantFloat),
 }
 
-ea_params = {"n_offsprings": 4, "tournament_size": 2, "n_processes": 2}
+ea_params = {"n_offsprings": 4, "n_processes": 2}
 
 evolve_params = {"max_generations": int(args["--max-generations"]), "min_fitness": 0.0}
 

--- a/examples/example_multi_genome.py
+++ b/examples/example_multi_genome.py
@@ -82,7 +82,7 @@ single_genome_params = {
 }
 genome_params = [single_genome_params, single_genome_params]
 
-ea_params = {"n_offsprings": 4, "tournament_size": 2, "n_processes": 1}
+ea_params = {"n_offsprings": 4, "n_processes": 1}
 
 evolve_params = {"max_generations": int(args["--max-generations"]), "min_fitness": 0.0}
 

--- a/examples/example_piecewise_target_function.py
+++ b/examples/example_piecewise_target_function.py
@@ -89,7 +89,7 @@ genome_params = {
     "primitives": (cgp.IfElse, cgp.Mul, cgp.Add, cgp.Sub, cgp.ConstantFloat,),
 }
 
-ea_params = {"n_offsprings": 4, "tournament_size": 2, "n_processes": 2}
+ea_params = {"n_offsprings": 4, "n_processes": 2}
 
 evolve_params = {"max_generations": int(args["--max-generations"]), "min_fitness": 0.0}
 

--- a/examples/example_reorder.py
+++ b/examples/example_reorder.py
@@ -85,10 +85,9 @@ genome_params = {
     "primitives": (cgp.Add, cgp.Sub, cgp.Mul, cgp.ConstantFloat),
 }
 
-ea_params = {"n_offsprings": 4, "tournament_size": 2, "n_processes": 2}
+ea_params = {"n_offsprings": 4, "n_processes": 2}
 ea_params_with_reorder = {
     "n_offsprings": 4,
-    "tournament_size": 2,
     "n_processes": 2,
     "reorder_genome": True,
 }

--- a/test/test_ea_mu_plus_lambda.py
+++ b/test/test_ea_mu_plus_lambda.py
@@ -71,9 +71,9 @@ def test_offspring_individuals_are_assigned_correct_parent_indices(
         return ind
 
     population_params["n_parents"] = 1
-
     pop = cgp.Population(**population_params, genome_params=genome_params)
 
+    ea_params["tournament_size"] = 1
     ea = cgp.ea.MuPlusLambda(**ea_params)
     ea.initialize_fitness_parents(pop, objective)
 


### PR DESCRIPTION
Makes the sanity check that the tournament size is smaller or equal to the number of parents in a population. Closes #246 
Note that this PR is not ready for merging - due to the sanity checks various examples now raise errors. (Will adapt if the concept is approved) 