### PR TITLE
Remove support for calling graph directly

### DIFF
--- a/cgp/cartesian_graph.py
+++ b/cgp/cartesian_graph.py
@@ -202,20 +202,6 @@ class CartesianGraph:
 
         return active_regions
 
-    def __call__(self, x: List[float]) -> List[float]:
-        # store values of x in input nodes
-        for i, xi in enumerate(x):
-            assert isinstance(self._nodes[i], InputNode)
-            self._nodes[i]._output = xi
-
-        # evaluate active nodes in order
-        active_nodes_by_hidden_column_idx = self._determine_active_nodes()
-        for hidden_column_idx in sorted(active_nodes_by_hidden_column_idx):
-            for node in active_nodes_by_hidden_column_idx[hidden_column_idx]:
-                node(x, self)
-
-        return [node._output for node in self.output_nodes]
-
     def __getitem__(self, key: int) -> Node:
         return self._nodes[key]
 

--- a/cgp/node.py
+++ b/cgp/node.py
@@ -57,9 +57,6 @@ class Node:
         super().__init_subclass__()
         register(cls)
 
-    def __call__(self, x: List[float], graph: "CartesianGraph") -> None:
-        raise NotImplementedError
-
     @property
     def arity(self) -> int:
         return self._arity
@@ -209,19 +206,6 @@ class OperatorNode(Node):
     @property
     def parameter_str(self) -> List[str]:
         return self._parameter_str
-
-    def __call__(self, x: List[float], graph: "CartesianGraph") -> None:
-        output_str = str(self._def_output)
-
-        if len(self._parameter_names) > 0:
-            raise RuntimeError("can not call a node that uses parameters")
-
-        for input_name in self._input_names:
-            idx = self._extract_index_from_input_name(input_name)
-            output_str = output_str.replace(input_name, f"{graph[self._input_nodes[idx]].output}")
-
-        exec_str = f"self._output = {output_str}"
-        exec(exec_str)
 
     def _replace_input_names(self, output_str: str, graph: "CartesianGraph") -> str:
         for input_name in self._input_names:

--- a/test/test_cartesian_graph.py
+++ b/test/test_cartesian_graph.py
@@ -7,28 +7,6 @@ import cgp
 from cgp.genome import ID_INPUT_NODE, ID_NON_CODING_GENE, ID_OUTPUT_NODE
 
 
-def test_direct_input_output():
-    params = {"n_inputs": 1, "n_outputs": 1, "n_columns": 3, "n_rows": 3, "levels_back": 2}
-    primitives = (cgp.Add, cgp.Sub)
-    genome = cgp.Genome(
-        params["n_inputs"],
-        params["n_outputs"],
-        params["n_columns"],
-        params["n_rows"],
-        params["levels_back"],
-        primitives,
-    )
-    genome.randomize(np.random)
-
-    genome[-2:] = [0, ID_NON_CODING_GENE]  # set inputs for output node to input node
-    graph = cgp.CartesianGraph(genome)
-
-    x = [2.14159]
-    y = graph(x)
-
-    assert x[0] == pytest.approx(y[0])
-
-
 def test_to_func_simple():
     primitives = (cgp.Add,)
     genome = cgp.Genome(2, 1, 1, 1, 1, primitives)

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -627,9 +627,7 @@ def test_custom_node_with_custom_atomic_operator():
     x = [5.0, 1.5]
     y_target = [2 * (x[0] + x[1])]
 
-    _test_to_x_compilations(
-        genome, x, y_target, test_to_sympy=False
-    )
+    _test_to_x_compilations(genome, x, y_target, test_to_sympy=False)
 
 
 def test_custom_node_with_custom_atomic_operator_with_external_library():
@@ -675,6 +673,4 @@ def test_custom_node_with_custom_atomic_operator_with_external_library():
     x = [5.0, 1.5]
     y_target = [scipy_const.golden_ratio * (x[0] + x[1])]
 
-    _test_to_x_compilations(
-        genome, x, y_target, test_to_sympy=False
-    )
+    _test_to_x_compilations(genome, x, y_target, test_to_sympy=False)

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -24,19 +24,16 @@ def test_inputs_are_cut_to_match_arity():
     assert node.input_nodes == input_nodes[:2]
 
 
-def _test_graph_call_and_to_x_compilations(
+def _test_to_x_compilations(
     genome,
     x,
     y_target,
     *,
-    test_graph_call=True,
     test_to_func=True,
     test_to_numpy=True,
     test_to_torch=True,
     test_to_sympy=True,
 ):
-    if test_graph_call:
-        _test_graph_call(genome, x, y_target)
     if test_to_func:
         _test_to_func(genome, x, y_target)
     if test_to_numpy:
@@ -45,11 +42,6 @@ def _test_graph_call_and_to_x_compilations(
         _test_to_torch(genome, x, y_target)
     if test_to_sympy:
         _test_to_sympy(genome, x, y_target)
-
-
-def _test_graph_call(genome, x, y_target):
-    graph = cgp.CartesianGraph(genome)
-    assert graph(x) == pytest.approx(y_target)
 
 
 def _test_to_func(genome, x, y_target):
@@ -107,7 +99,7 @@ def test_add():
     x = [5.0, 1.5]
     y_target = [x[0] + x[1]]
 
-    _test_graph_call_and_to_x_compilations(genome, x, y_target)
+    _test_to_x_compilations(genome, x, y_target)
 
 
 def test_sub():
@@ -141,7 +133,7 @@ def test_sub():
     x = [5.0, 1.5]
     y_target = [x[0] - x[1]]
 
-    _test_graph_call_and_to_x_compilations(genome, x, y_target)
+    _test_to_x_compilations(genome, x, y_target)
 
 
 def test_mul():
@@ -175,7 +167,7 @@ def test_mul():
     x = [5.0, 1.5]
     y_target = [x[0] * x[1]]
 
-    _test_graph_call_and_to_x_compilations(genome, x, y_target)
+    _test_to_x_compilations(genome, x, y_target)
 
 
 def test_div():
@@ -209,7 +201,7 @@ def test_div():
     x = [5.0, 1.5]
     y_target = [x[0] / x[1]]
 
-    _test_graph_call_and_to_x_compilations(genome, x, y_target)
+    _test_to_x_compilations(genome, x, y_target)
 
 
 def test_pow():
@@ -243,7 +235,7 @@ def test_pow():
     x = [5.0, 1.5]
     y_target = [x[0] ** x[1]]
 
-    _test_graph_call_and_to_x_compilations(genome, x, y_target)
+    _test_to_x_compilations(genome, x, y_target)
 
 
 def test_constant_float():
@@ -273,7 +265,7 @@ def test_constant_float():
     x = [1.0, 2.0]
     y_target = [1.0]  # by default the output value of the ConstantFloat node is 1.0
 
-    _test_graph_call_and_to_x_compilations(genome, x, y_target)
+    _test_to_x_compilations(genome, x, y_target)
 
 
 def test_parameter():
@@ -292,7 +284,7 @@ def test_parameter():
     x = [1.0]
     y_target = [1.0]  # by default the output value of the Parameter node is 1.0
 
-    _test_graph_call_and_to_x_compilations(genome, x, y_target, test_graph_call=False)
+    _test_to_x_compilations(genome, x, y_target)
 
 
 def test_parameter_w_custom_initial_value():
@@ -316,7 +308,7 @@ def test_parameter_w_custom_initial_value():
     x = [1.0]
     y_target = [initial_value]
 
-    _test_graph_call_and_to_x_compilations(genome, x, y_target, test_graph_call=False)
+    _test_to_x_compilations(genome, x, y_target)
 
 
 def test_parameter_two_nodes():
@@ -353,7 +345,7 @@ def test_parameter_two_nodes():
     # hence the sum of two Parameter nodes is 2.0
     y_target = [2.0]
 
-    _test_graph_call_and_to_x_compilations(genome, x, y_target, test_graph_call=False)
+    _test_to_x_compilations(genome, x, y_target)
 
 
 def test_parameter_w_random_initial_value(rng_seed):
@@ -486,15 +478,15 @@ def test_if_else_operator():
 
     x_0 = [1.0, 10.0, -20.0]
     y_target_0 = [10.0]
-    _test_graph_call_and_to_x_compilations(genome, x_0, y_target_0)
+    _test_to_x_compilations(genome, x_0, y_target_0)
 
     x_1 = [0.0, 10.0, -20.0]
     y_target_1 = [10.0]
-    _test_graph_call_and_to_x_compilations(genome, x_1, y_target_1)
+    _test_to_x_compilations(genome, x_1, y_target_1)
 
     x_2 = [-1.0, 10.0, -20.0]
     y_target_2 = [-20.0]
-    _test_graph_call_and_to_x_compilations(genome, x_2, y_target_2)
+    _test_to_x_compilations(genome, x_2, y_target_2)
 
 
 def test_raise_broken_def_output():
@@ -591,7 +583,7 @@ def test_custom_node():
     x = [5.0, 1.5]
     y_target = [2 * (x[0] + x[1])]
 
-    _test_graph_call_and_to_x_compilations(genome, x, y_target)
+    _test_to_x_compilations(genome, x, y_target)
 
 
 def test_custom_node_with_custom_atomic_operator():
@@ -635,8 +627,8 @@ def test_custom_node_with_custom_atomic_operator():
     x = [5.0, 1.5]
     y_target = [2 * (x[0] + x[1])]
 
-    _test_graph_call_and_to_x_compilations(
-        genome, x, y_target, test_graph_call=False, test_to_sympy=False
+    _test_to_x_compilations(
+        genome, x, y_target, test_to_sympy=False
     )
 
 
@@ -683,6 +675,6 @@ def test_custom_node_with_custom_atomic_operator_with_external_library():
     x = [5.0, 1.5]
     y_target = [scipy_const.golden_ratio * (x[0] + x[1])]
 
-    _test_graph_call_and_to_x_compilations(
-        genome, x, y_target, test_graph_call=False, test_to_sympy=False
+    _test_to_x_compilations(
+        genome, x, y_target, test_to_sympy=False
     )


### PR DESCRIPTION
There does not seem to be any need for calling the graph object directly. As soon as more than a single call is required, the `to_...` versions are much faster as they only require traversing the cartesian graph once.

This PR hence removes support for this functionality to i) prevent users from accidentally making their code slow and ii) relieve us of the burden of maintaining it.