### PR TITLE
Fix error message wrong size passed to to_torch/to_numpy graphs

### DIFF
--- a/cgp/cartesian_graph.py
+++ b/cgp/cartesian_graph.py
@@ -281,13 +281,9 @@ def _f(x):
         s = ", ".join(node.output_str for node in self.output_nodes)
         func_str = f"""\
 def _f(x):
-    if len(x.shape) != 2:
+    if (len(x.shape) != 2) or (x.shape[1] != {self._n_inputs}):
         raise ValueError(
             f"input has shape {{tuple(x.shape)}}, expected (<batch_size>, {self._n_inputs})"
-        )
-    if x.shape[1] != {self._n_inputs}:
-        raise ValueError(
-            f"input has shape {{tuple(x.shape)}}, expected ({{x.shape[0]}}, {self._n_inputs})"
         )
 
     return np.stack([{s}], axis=1)
@@ -339,13 +335,9 @@ class _C(torch.nn.Module):
         func_str = f"""\
 
     def forward(self, x):
-        if len(x.shape) != 2:
+        if (len(x.shape) != 2) or (x.shape[1] != {self._n_inputs}):
             raise ValueError(
                 f"input has shape {{tuple(x.shape)}}, expected (<batch_size>, {self._n_inputs})"
-            )
-        if x.shape[1] != {self._n_inputs}:
-            raise ValueError(
-                f"input has shape {{tuple(x.shape)}}, expected ({{x.shape[0]}}, {self._n_inputs})"
             )
         return torch.stack([{forward_str}], dim=1)
         """


### PR DESCRIPTION
The current error message can be a bit confusing as we are trying to guess the batch dimension. If someone provides a transposed array with shape, e.g., (2, 200) to a graph with two inputs, the message claims the input should have shape (2, 2), while the correct size would be (200, 2).

This PR changes the error message to avoid such confusing output.