### PR TITLE
Make levels_back parameter optional

### DIFF
--- a/cgp/genome.py
+++ b/cgp/genome.py
@@ -30,8 +30,8 @@ class Genome:
         n_outputs: int,
         n_columns: int,
         n_rows: int,
-        levels_back: Union[int, None],
         primitives: Tuple[Type[Node], ...],
+        levels_back: Union[int, None] = None,
     ) -> None:
         """Init function.
 
@@ -45,11 +45,11 @@ class Genome:
             Number of columns in the representation of the genome.
         n_rows : int
             Number of rows in the representation of the genome.
-        levels_back : Union[int, None]
-            Maximal column distance of inputs to an internal node. If
-            set to `None`, no restrictions are used.
         primitives : Tuple[Type[Node], ...]
            Tuple of primitives that the genome can refer to.
+        levels_back : Union[int, None]
+            Maximal column distance of inputs to an internal node. If
+            set to `None`, no restrictions are used. Defaults to None
 
         """
         if n_inputs <= 0:
@@ -70,7 +70,7 @@ class Genome:
 
         if levels_back is None:
             levels_back = n_columns
-        if levels_back == 0:
+        if levels_back == 0 and n_columns != 0:
             raise ValueError("levels_back must be strictly positive")
         if levels_back > n_columns:
             raise ValueError("levels_back can not be larger than n_columns")
@@ -673,8 +673,8 @@ class Genome:
             self._n_outputs,
             self._n_columns,
             self._n_rows,
-            self._levels_back,
             tuple(self._primitives),
+            self._levels_back,
         )
         new.dna = self.dna.copy()
 

--- a/cgp/node_validation.py
+++ b/cgp/node_validation.py
@@ -28,7 +28,7 @@ def _create_genome(cls: Type["OperatorNode"]) -> "Genome":
     from .genome import ID_INPUT_NODE, ID_NON_CODING_GENE, ID_OUTPUT_NODE, Genome
 
     primitives = (cls,)
-    genome = Genome(1, 1, 1, 1, 1, primitives)
+    genome = Genome(1, 1, 1, 1, primitives)
     dna = [ID_INPUT_NODE]
     arity = max(cls._arity, 1)
     for _ in range(arity):

--- a/test/test_cartesian_graph.py
+++ b/test/test_cartesian_graph.py
@@ -9,7 +9,7 @@ from cgp.genome import ID_INPUT_NODE, ID_NON_CODING_GENE, ID_OUTPUT_NODE
 
 def test_to_func_simple():
     primitives = (cgp.Add,)
-    genome = cgp.Genome(2, 1, 1, 1, 1, primitives)
+    genome = cgp.Genome(2, 1, 1, 1, primitives)
 
     genome.dna = [
         ID_INPUT_NODE,
@@ -34,7 +34,7 @@ def test_to_func_simple():
     assert x[0] + x[1] == pytest.approx(y[0])
 
     primitives = (cgp.Sub,)
-    genome = cgp.Genome(2, 1, 1, 1, 1, primitives)
+    genome = cgp.Genome(2, 1, 1, 1, primitives)
 
     genome.dna = [
         ID_INPUT_NODE,
@@ -61,7 +61,7 @@ def test_to_func_simple():
 
 def test_compile_two_columns():
     primitives = (cgp.Add, cgp.Sub)
-    genome = cgp.Genome(2, 1, 2, 1, 1, primitives)
+    genome = cgp.Genome(2, 1, 2, 1, primitives, 1)
 
     genome.dna = [
         ID_INPUT_NODE,
@@ -91,7 +91,7 @@ def test_compile_two_columns():
 
 def test_compile_two_columns_two_rows():
     primitives = (cgp.Add, cgp.Sub)
-    genome = cgp.Genome(2, 2, 2, 2, 1, primitives)
+    genome = cgp.Genome(2, 2, 2, 2, primitives, 1)
 
     genome.dna = [
         ID_INPUT_NODE,
@@ -138,8 +138,8 @@ def test_compile_addsubmul():
         params["n_outputs"],
         params["n_columns"],
         params["n_rows"],
-        params["levels_back"],
         primitives,
+        params["levels_back"],
     )
     genome.dna = [
         ID_INPUT_NODE,
@@ -175,7 +175,7 @@ def test_compile_addsubmul():
 
 def test_to_numpy():
     primitives = (cgp.Add, cgp.Mul, cgp.ConstantFloat)
-    genome = cgp.Genome(1, 1, 2, 2, 1, primitives)
+    genome = cgp.Genome(1, 1, 2, 2, primitives, 1)
     # f(x) = x ** 2 + 1.
     genome.dna = [
         ID_INPUT_NODE,
@@ -209,7 +209,7 @@ def test_to_numpy():
 
 batch_sizes = [1, 10]
 primitives = (cgp.Mul, cgp.ConstantFloat)
-genome = [cgp.Genome(1, 1, 2, 2, 1, primitives) for i in range(2)]
+genome = [cgp.Genome(1, 1, 2, 2, primitives, 1) for i in range(2)]
 # Function: f(x) = 1*x
 genome[0].dna = [
     ID_INPUT_NODE,
@@ -253,7 +253,7 @@ genome[1].dna = [
     ID_NON_CODING_GENE,
 ]
 
-genome += [cgp.Genome(1, 2, 2, 2, 1, primitives) for i in range(2)]
+genome += [cgp.Genome(1, 2, 2, 2, primitives, 1) for i in range(2)]
 # Function: f(x) = (1*x, 1*1)
 genome[2].dna = [
     ID_INPUT_NODE,
@@ -327,7 +327,7 @@ def test_to_sympy():
     sympy = pytest.importorskip("sympy")
 
     primitives = (cgp.Add, cgp.ConstantFloat)
-    genome = cgp.Genome(1, 1, 2, 2, 1, primitives)
+    genome = cgp.Genome(1, 1, 2, 2, primitives, 1)
 
     # f = x_0 + x_0 + 1.0
     genome.dna = [
@@ -368,7 +368,7 @@ def test_allow_sympy_expr_with_infinities():
     pytest.importorskip("sympy")
 
     primitives = (cgp.Sub, cgp.Div)
-    genome = cgp.Genome(1, 1, 2, 1, 1, primitives)
+    genome = cgp.Genome(1, 1, 2, 1, primitives, 1)
 
     # x[0] / (x[0] - x[0])
     genome.dna = [
@@ -396,7 +396,7 @@ def test_allow_powers_of_x_0():
     pytest.importorskip("sympy")
 
     primitives = (cgp.Sub, cgp.Mul)
-    genome = cgp.Genome(1, 1, 2, 1, 1, primitives)
+    genome = cgp.Genome(1, 1, 2, 1, primitives, 1)
 
     # x[0] ** 2
     genome.dna = [
@@ -420,7 +420,7 @@ def test_allow_powers_of_x_0():
 def test_input_dim_python(rng_seed):
     rng = np.random.RandomState(rng_seed)
 
-    genome = cgp.Genome(2, 1, 1, 1, 1, (cgp.ConstantFloat,))
+    genome = cgp.Genome(2, 1, 1, 1, (cgp.ConstantFloat,))
     genome.randomize(rng)
     f = cgp.CartesianGraph(genome).to_func()
 
@@ -439,7 +439,7 @@ def test_input_dim_python(rng_seed):
 def test_input_dim_numpy(rng_seed):
     rng = np.random.RandomState(rng_seed)
 
-    genome = cgp.Genome(2, 1, 1, 1, 1, (cgp.ConstantFloat,))
+    genome = cgp.Genome(2, 1, 1, 1, (cgp.ConstantFloat,))
     genome.randomize(rng)
     f = cgp.CartesianGraph(genome).to_numpy()
 
@@ -464,7 +464,7 @@ def test_input_dim_torch(rng_seed):
 
     rng = np.random.RandomState(rng_seed)
 
-    genome = cgp.Genome(2, 1, 1, 1, 1, (cgp.ConstantFloat,))
+    genome = cgp.Genome(2, 1, 1, 1, (cgp.ConstantFloat,))
     genome.randomize(rng)
     f = cgp.CartesianGraph(genome).to_torch()
 
@@ -486,7 +486,7 @@ def test_input_dim_torch(rng_seed):
 
 def test_pretty_str():
     primitives = (cgp.Sub, cgp.Mul)
-    genome = cgp.Genome(1, 1, 2, 1, 1, primitives)
+    genome = cgp.Genome(1, 1, 2, 1, primitives, 1)
 
     # x[0] ** 2
     genome.dna = [
@@ -519,7 +519,7 @@ def test_pretty_str_with_unequal_inputs_rows_outputs():
     primitives = (cgp.Add,)
 
     # less rows than inputs/outputs
-    genome = cgp.Genome(1, 1, 1, 2, 1, primitives)
+    genome = cgp.Genome(1, 1, 1, 2, primitives)
     # f(x) = x[0] + x[0]
     genome.dna = [
         ID_INPUT_NODE,
@@ -544,7 +544,7 @@ def test_pretty_str_with_unequal_inputs_rows_outputs():
     assert graph.pretty_str() == expected_pretty_str
 
     # more rows than inputs/outputs
-    genome = cgp.Genome(3, 3, 1, 2, 1, primitives)
+    genome = cgp.Genome(3, 3, 1, 2, primitives)
     # f(x) = [x[0] + x[1], x[0] + x[1], x[1] + x[2]]
     genome.dna = [
         ID_INPUT_NODE,

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -9,16 +9,11 @@ from cgp.genome import ID_INPUT_NODE, ID_NON_CODING_GENE, ID_OUTPUT_NODE
 
 
 def test_check_dna_consistency():
-    params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1, "levels_back": 1}
+    params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1}
 
     primitives = (cgp.Add,)
     genome = cgp.Genome(
-        params["n_inputs"],
-        params["n_outputs"],
-        params["n_columns"],
-        params["n_rows"],
-        params["levels_back"],
-        primitives,
+        params["n_inputs"], params["n_outputs"], params["n_columns"], params["n_rows"], primitives,
     )
     genome.dna = [
         ID_INPUT_NODE,
@@ -182,8 +177,8 @@ def test_permissible_addresses():
         params["n_outputs"],
         params["n_columns"],
         params["n_rows"],
-        params["levels_back"],
         primitives,
+        params["levels_back"],
     )
     genome.randomize(np.random)
 
@@ -211,16 +206,11 @@ def test_permissible_addresses():
 
 
 def test_region_iterators():
-    params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1, "levels_back": 1}
+    params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1}
 
     primitives = (cgp.Add,)
     genome = cgp.Genome(
-        params["n_inputs"],
-        params["n_outputs"],
-        params["n_columns"],
-        params["n_rows"],
-        params["levels_back"],
-        primitives,
+        params["n_inputs"], params["n_outputs"], params["n_columns"], params["n_rows"], primitives,
     )
     genome.dna = [
         ID_INPUT_NODE,
@@ -259,8 +249,8 @@ def test_check_levels_back_consistency():
             params["n_outputs"],
             params["n_columns"],
             params["n_rows"],
-            params["levels_back"],
             primitives,
+            params["levels_back"],
         )
 
     params["levels_back"] = params["n_columns"] + 1
@@ -270,8 +260,8 @@ def test_check_levels_back_consistency():
             params["n_outputs"],
             params["n_columns"],
             params["n_rows"],
-            params["levels_back"],
             primitives,
+            params["levels_back"],
         )
 
     params["levels_back"] = params["n_columns"] - 1
@@ -280,14 +270,14 @@ def test_check_levels_back_consistency():
         params["n_outputs"],
         params["n_columns"],
         params["n_rows"],
-        params["levels_back"],
         primitives,
+        params["levels_back"],
     )
 
 
 def test_catch_invalid_allele_in_inactive_region():
     primitives = (cgp.ConstantFloat,)
-    genome = cgp.Genome(1, 1, 1, 1, 1, primitives)
+    genome = cgp.Genome(1, 1, 1, 1, primitives)
 
     # should raise error: ConstantFloat node has no addresses, but silent
     # address gene should still specify valid address
@@ -321,7 +311,7 @@ def test_individuals_have_different_genome(population_params, genome_params, ea_
 
 
 def test_is_gene_in_input_region(rng_seed):
-    genome = cgp.Genome(2, 1, 2, 1, None, (cgp.Add,))
+    genome = cgp.Genome(2, 1, 2, 1, (cgp.Add,))
     rng = np.random.RandomState(rng_seed)
     genome.randomize(rng)
 
@@ -330,7 +320,7 @@ def test_is_gene_in_input_region(rng_seed):
 
 
 def test_is_gene_in_hidden_region(rng_seed):
-    genome = cgp.Genome(2, 1, 2, 1, None, (cgp.Add,))
+    genome = cgp.Genome(2, 1, 2, 1, (cgp.Add,))
     rng = np.random.RandomState(rng_seed)
     genome.randomize(rng)
 
@@ -341,7 +331,7 @@ def test_is_gene_in_hidden_region(rng_seed):
 
 
 def test_is_gene_in_output_region(rng_seed):
-    genome = cgp.Genome(2, 1, 2, 1, None, (cgp.Add,))
+    genome = cgp.Genome(2, 1, 2, 1, (cgp.Add,))
     rng = np.random.RandomState(rng_seed)
     genome.randomize(rng)
 
@@ -354,7 +344,7 @@ def test_mutation_rate(rng_seed, mutation_rate):
     n_outputs = 1
     n_columns = 4
     n_rows = 3
-    genome = cgp.Genome(n_inputs, n_outputs, n_columns, n_rows, None, (cgp.Add, cgp.Sub))
+    genome = cgp.Genome(n_inputs, n_outputs, n_columns, n_rows, (cgp.Add, cgp.Sub))
     rng = np.random.RandomState(rng_seed)
     genome.randomize(rng)
 
@@ -485,7 +475,7 @@ def test_permissible_values(genome_params):
     n_rows = 3
     levels_back = 2
     primitives = (cgp.Add, cgp.Sub, cgp.ConstantFloat)
-    genome = cgp.Genome(n_inputs, n_outputs, n_columns, n_rows, levels_back, primitives)
+    genome = cgp.Genome(n_inputs, n_outputs, n_columns, n_rows, primitives, levels_back)
 
     permissible_function_gene_values = np.arange(len(genome._primitives._primitives))
     permissible_addresses_first_internal_column = np.array([0, 1])
@@ -560,7 +550,6 @@ def test_genome_reordering_empirically(rng):
         "n_outputs": 1,
         "n_columns": 14,
         "n_rows": 1,
-        "levels_back": None,
         "primitives": (cgp.Mul, cgp.Sub, cgp.Add, cgp.ConstantFloat, cgp.Parameter),
     }
 
@@ -641,7 +630,6 @@ def test_genome_reordering_parameterization_consistency(rng):
         "n_outputs": 1,
         "n_columns": 10,
         "n_rows": 2,
-        "levels_back": None,
         "primitives": (cgp.Mul, cgp.Sub, cgp.Add, cgp.ConstantFloat),
     }
 
@@ -655,8 +643,8 @@ def test_genome_reordering_parameterization_consistency(rng):
         "n_outputs": 1,
         "n_columns": 10,
         "n_rows": 1,
-        "levels_back": 5,
         "primitives": (cgp.Mul, cgp.Sub, cgp.Add, cgp.ConstantFloat),
+        "levels_back": 5,
     }
 
     genome = cgp.Genome(**genome_params)

--- a/test/test_individual.py
+++ b/test/test_individual.py
@@ -85,7 +85,7 @@ def _unpack_genome(individual, individual_type="SingleGenome"):
 def test_pickle_individual(individual_type):
 
     primitives = (cgp.Add,)
-    genome = cgp.Genome(1, 1, 1, 1, 1, primitives)
+    genome = cgp.Genome(1, 1, 1, 1, primitives)
     individual = _create_individual(genome, individual_type=individual_type)
 
     with open("individual.pkl", "wb") as f:
@@ -167,7 +167,7 @@ def test_individual_with_parameter_numpy(individual_type, params, graph_input_va
 def test_to_and_from_torch_plus_backprop(individual_type):
     torch = pytest.importorskip("torch")
     primitives = (cgp.Mul, cgp.Parameter)
-    genome = cgp.Genome(1, 1, 2, 2, 1, primitives)
+    genome = cgp.Genome(1, 1, 2, 2, primitives, 1)
     # f(x) = c * x
     genome.dna = [
         ID_INPUT_NODE,
@@ -233,7 +233,7 @@ def test_to_and_from_torch_plus_backprop(individual_type):
 def test_update_parameters_from_torch_class_resets_fitness(individual_type):
     pytest.importorskip("torch")
     primitives = (cgp.Mul, cgp.Parameter)
-    genome = cgp.Genome(1, 1, 2, 1, 1, primitives)
+    genome = cgp.Genome(1, 1, 2, 1, primitives, 1)
     # f(x) = c * x
     genome.dna = [
         ID_INPUT_NODE,
@@ -271,7 +271,7 @@ def test_update_parameters_from_torch_class_does_not_reset_fitness_for_unused_pa
 ):
     pytest.importorskip("torch")
     primitives = (cgp.Mul, cgp.Parameter)
-    genome = cgp.Genome(1, 1, 2, 1, 1, primitives)
+    genome = cgp.Genome(1, 1, 2, 1, primitives, 1)
     # f(x) = x ** 2
     genome.dna = [
         ID_INPUT_NODE,
@@ -305,7 +305,7 @@ def test_update_parameters_from_torch_class_does_not_reset_fitness_for_unused_pa
 def test_individual_randomize_genome(individual_type, rng_seed):
     rng = np.random.RandomState(rng_seed)
     primitives = (cgp.Add, cgp.Mul)
-    genome = cgp.Genome(1, 1, 2, 1, 1, primitives)
+    genome = cgp.Genome(1, 1, 2, 1, primitives, 1)
     genome.randomize(rng)
 
     dna_old = list(genome.dna)

--- a/test/test_local_search.py
+++ b/test/test_local_search.py
@@ -8,7 +8,7 @@ def test_gradient_based_step_towards_maximum():
     torch = pytest.importorskip("torch")
 
     primitives = (cgp.Parameter,)
-    genome = cgp.Genome(1, 1, 1, 1, 1, primitives)
+    genome = cgp.Genome(1, 1, 1, 1, primitives)
     # f(x) = c
     genome.dna = [ID_INPUT_NODE, ID_NON_CODING_GENE, 0, 0, ID_OUTPUT_NODE, 1]
     ind = cgp.individual.IndividualSingleGenome(genome)
@@ -38,7 +38,7 @@ def test_gradient_based_step_towards_maximum_multi_genome():
     torch = pytest.importorskip("torch")
 
     primitives = (cgp.Parameter,)
-    genome = cgp.Genome(1, 1, 1, 1, 1, primitives)
+    genome = cgp.Genome(1, 1, 1, 1, primitives)
     # f(x) = c
     genome.dna = [ID_INPUT_NODE, ID_NON_CODING_GENE, 0, 0, ID_OUTPUT_NODE, 1]
     genome2 = genome.clone()

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -69,16 +69,11 @@ def _test_to_sympy(genome, x, y_target):
 
 
 def test_add():
-    params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1, "levels_back": 1}
+    params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1}
 
     primitives = (cgp.Add,)
     genome = cgp.Genome(
-        params["n_inputs"],
-        params["n_outputs"],
-        params["n_columns"],
-        params["n_rows"],
-        params["levels_back"],
-        primitives,
+        params["n_inputs"], params["n_outputs"], params["n_columns"], params["n_rows"], primitives,
     )
     # f(x) = x[0] + x[1]
     genome.dna = [
@@ -103,16 +98,11 @@ def test_add():
 
 
 def test_sub():
-    params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1, "levels_back": 1}
+    params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1}
 
     primitives = (cgp.Sub,)
     genome = cgp.Genome(
-        params["n_inputs"],
-        params["n_outputs"],
-        params["n_columns"],
-        params["n_rows"],
-        params["levels_back"],
-        primitives,
+        params["n_inputs"], params["n_outputs"], params["n_columns"], params["n_rows"], primitives,
     )
     # f(x) = x[0] - x[1]
     genome.dna = [
@@ -137,16 +127,11 @@ def test_sub():
 
 
 def test_mul():
-    params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1, "levels_back": 1}
+    params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1}
 
     primitives = (cgp.Mul,)
     genome = cgp.Genome(
-        params["n_inputs"],
-        params["n_outputs"],
-        params["n_columns"],
-        params["n_rows"],
-        params["levels_back"],
-        primitives,
+        params["n_inputs"], params["n_outputs"], params["n_columns"], params["n_rows"], primitives,
     )
     # f(x) = x[0] * x[1]
     genome.dna = [
@@ -171,16 +156,11 @@ def test_mul():
 
 
 def test_div():
-    params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1, "levels_back": 1}
+    params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1}
 
     primitives = (cgp.Div,)
     genome = cgp.Genome(
-        params["n_inputs"],
-        params["n_outputs"],
-        params["n_columns"],
-        params["n_rows"],
-        params["levels_back"],
-        primitives,
+        params["n_inputs"], params["n_outputs"], params["n_columns"], params["n_rows"], primitives,
     )
     # f(x) = x[0] / x[1]
     genome.dna = [
@@ -205,16 +185,11 @@ def test_div():
 
 
 def test_pow():
-    params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1, "levels_back": 1}
+    params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1}
 
     primitives = (cgp.Pow,)
     genome = cgp.Genome(
-        params["n_inputs"],
-        params["n_outputs"],
-        params["n_columns"],
-        params["n_rows"],
-        params["levels_back"],
-        primitives,
+        params["n_inputs"], params["n_outputs"], params["n_columns"], params["n_rows"], primitives,
     )
     # f(x) = x[0] ** x[1]
     genome.dna = [
@@ -239,17 +214,12 @@ def test_pow():
 
 
 def test_constant_float():
-    params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1, "levels_back": 1}
+    params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1}
 
     primitives = (cgp.ConstantFloat,)
     # f(x) = c
     genome = cgp.Genome(
-        params["n_inputs"],
-        params["n_outputs"],
-        params["n_columns"],
-        params["n_rows"],
-        params["levels_back"],
-        primitives,
+        params["n_inputs"], params["n_outputs"], params["n_columns"], params["n_rows"], primitives,
     )
     genome.dna = [
         ID_INPUT_NODE,
@@ -274,7 +244,6 @@ def test_parameter():
         "n_outputs": 1,
         "n_columns": 1,
         "n_rows": 1,
-        "levels_back": None,
     }
     primitives = (cgp.Parameter,)
     genome = cgp.Genome(**genome_params, primitives=primitives)
@@ -298,7 +267,6 @@ def test_parameter_w_custom_initial_value():
         "n_outputs": 1,
         "n_columns": 1,
         "n_rows": 1,
-        "levels_back": None,
     }
     primitives = (CustomParameter,)
     genome = cgp.Genome(**genome_params, primitives=primitives)
@@ -317,7 +285,6 @@ def test_parameter_two_nodes():
         "n_outputs": 1,
         "n_columns": 3,
         "n_rows": 1,
-        "levels_back": None,
     }
     primitives = (cgp.Parameter, cgp.Add)
     genome = cgp.Genome(**genome_params, primitives=primitives)
@@ -362,7 +329,6 @@ def test_parameter_w_random_initial_value(rng_seed):
         "n_outputs": 1,
         "n_columns": 1,
         "n_rows": 1,
-        "levels_back": None,
     }
     primitives = (CustomParameter,)
     genome = cgp.Genome(**genome_params, primitives=primitives)
@@ -393,7 +359,6 @@ def test_multiple_parameters_per_node():
         "n_outputs": 1,
         "n_columns": 1,
         "n_rows": 1,
-        "levels_back": None,
     }
     primitives = (DoubleParameter,)
     genome = cgp.Genome(**genome_params, primitives=primitives)
@@ -414,7 +379,6 @@ def test_reset_parameters_upon_creation_of_node(rng):
         "n_outputs": 1,
         "n_columns": 1,
         "n_rows": 1,
-        "levels_back": None,
     }
     primitives = (CustomParameter, CustomParameter)
     genome = cgp.Genome(**genome_params, primitives=primitives)
@@ -447,7 +411,6 @@ def test_if_else_operator():
         "n_outputs": 1,
         "n_columns": 1,
         "n_rows": 1,
-        "levels_back": None,
     }
     primitives = (cgp.IfElse,)
     genome = cgp.Genome(**genome_params, primitives=primitives)


### PR DESCRIPTION
Addresses #276. There is one minor thing: The current checks allow `n_columns=0` and set `levels_back=n_columns` (if None provided), but they don't allow `levels_back=0` 
This could lead to confusing error messages