### PR TITLE
Allow custom functions to be used for computing cache keys

### DIFF
--- a/examples/example_caching.py
+++ b/examples/example_caching.py
@@ -30,18 +30,20 @@ def f_target(x):
 # function to compute (or retrieve from cache) the fitness of the individual.
 
 
-@cgp.utils.disk_cache("example_caching_cache.pkl")
-def inner_objective(expr):
+@cgp.utils.disk_cache(
+    "example_caching_cache.pkl", compute_key=cgp.utils.compute_key_from_sympy_expr_and_args
+)
+def inner_objective(ind):
     """The caching decorator uses the function parameters to identify
     identical function calls. Here, as many different genotypes
-    produce the same simplified SymPy expression we can use such
-    expressions as an argument to the decorated function to avoid
-    reevaluating functionally identical individuals.
-    Note that caching only makes sense for deterministic objective
-    functions, as it assumes that identical expressions will always
-    return the same fitness values.
+    produce the same simplified SymPy expression we can use these
+    avoid reevaluating functionally identical individuals. Note that
+    caching only makes sense for deterministic objective functions, as
+    it assumes that identical expressions will always return the same
+    fitness values.
 
     """
+    expr = ind.to_sympy()
     loss = []
     for x0 in np.linspace(-2.0, 2.0, 100):
         y = float(expr[0].subs({"x_0": x0}).evalf())
@@ -56,7 +58,7 @@ def objective(individual):
     if not individual.fitness_is_None():
         return individual
 
-    individual.fitness = -inner_objective(individual.to_sympy())
+    individual.fitness = -inner_objective(individual)
 
     return individual
 

--- a/examples/example_fec_caching.py
+++ b/examples/example_fec_caching.py
@@ -10,6 +10,7 @@ second time and when you comment out the decorator on
 
 """
 
+import functools
 import multiprocessing as mp
 import time
 
@@ -38,11 +39,13 @@ def f_target(x):
 
 @cgp.utils.disk_cache(
     "example_fec_caching_cache.pkl",
-    use_fec=True,
-    fec_seed=12345,
-    fec_min_value=-10.0,
-    fec_max_value=10.0,
-    fec_batch_size=5,
+    compute_key=functools.partial(
+        cgp.utils.compute_key_from_numpy_evaluation_and_args,
+        _seed=12345,
+        _min_value=-10.0,
+        _max_value=10.0,
+        _batch_size=5,
+    ),
     file_lock=mp.Lock(),
 )
 def inner_objective(ind):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -73,3 +73,10 @@ def n_offsprings():
 @fixture
 def tournament_size():
     return 2
+
+
+@fixture
+def individual(genome_params, rng):
+    g = cgp.Genome(**genome_params)
+    g.randomize(rng)
+    return cgp.IndividualSingleGenome(g)


### PR DESCRIPTION
Currently the user can choose between computing a key for the disk cache all arguments and keyword arguments to the decorated function or from the result of evaluating an individual on random numpy arrays and the remaining arguments and keyword arguments.

This PR allows users to specify a function that is used to compute the key for the cache. Two functions are provided by the library: one uses the sympy expression of an individual and the remaining arguments, one the results of evaluating the individual on random numpy arrays and the remaining arguments. In addition the user can define any custom function they like provided its first argument is an individual instance and its return value is a float.