### PR TITLE
Use mp fork context by default, but allow switching to spawn context

### DIFF
--- a/cgp/__init__.py
+++ b/cgp/__init__.py
@@ -11,6 +11,7 @@ from .cartesian_graph import CartesianGraph, atomic_operator
 from .genome import Genome
 from .hl_api import evolve
 from .individual import IndividualMultiGenome, IndividualSingleGenome
+from .mp_context import fork_context, spawn_context
 from .node import OperatorNode
 from .node_impl import Add, ConstantFloat, Div, IfElse, Mul, Parameter, Pow, Sub
 from .population import Population

--- a/cgp/ea/mu_plus_lambda.py
+++ b/cgp/ea/mu_plus_lambda.py
@@ -4,6 +4,7 @@ from typing import Callable, List, Union
 import numpy as np
 
 from ..individual import IndividualBase
+from ..mp_context import fork_context, spawn_context
 from ..population import Population
 
 
@@ -78,7 +79,7 @@ class MuPlusLambda:
 
         self.process_pool: Union[None, "mp.pool.Pool"]
         if self.n_processes > 1:
-            self.process_pool = mp.Pool(processes=self.n_processes)
+            self.process_pool = fork_context.Pool(processes=self.n_processes)
         else:
             self.process_pool = None
         self.n_objective_calls: int = 0
@@ -283,3 +284,8 @@ class MuPlusLambda:
         for off in offsprings:
             off.mutate(self._mutation_rate, rng)
         return offsprings
+
+    def use_spawn_context(self):
+        assert self.n_processes > 1
+        self.process_pool.close()
+        self.process_pool = spawn_context.Pool(processes=self.n_processes)

--- a/cgp/mp_context.py
+++ b/cgp/mp_context.py
@@ -1,0 +1,4 @@
+import multiprocessing as mp
+
+fork_context: mp.context.ForkContext = mp.get_context("fork")
+spawn_context: mp.context.SpawnContext = mp.get_context("spawn")

--- a/cgp/utils.py
+++ b/cgp/utils.py
@@ -220,7 +220,7 @@ def disk_cache(
         __check_cache_consistency(fn, func)
 
         @functools.wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Union[float, None]:
+        def wrapper(*args: Any, **kwargs: Any) -> float:
 
             key: str
             if use_fec:


### PR DESCRIPTION
This PR introduces custom fork and spawn context for our library. Be default the default is used ("fork"), but the user may switch to the "spawn" context by calling `ea.use_spawn_context()` after creating an instance of `MuPlusLambda`. The implementation tries to have minimal impact on the user experience while fixing fixing issues with autograd in connection with forked processes.

fixes #274 