### PR TITLE
Redesign signatures of compilation targets

### DIFF
--- a/cgp/node_impl.py
+++ b/cgp/node_impl.py
@@ -6,7 +6,7 @@ class ConstantFloat(OperatorNode):
 
     _arity = 0
     _def_output = "1.0"
-    _def_numpy_output = "np.ones(x.shape[0]) * 1.0"
+    _def_numpy_output = "np.ones(len(x[0])) * 1.0"
     _def_torch_output = "torch.ones(1).expand(x.shape[0]) * 1.0"
 
 
@@ -57,7 +57,7 @@ class Parameter(OperatorNode):
     _arity = 0
     _initial_values = {"<p>": lambda: 1.0}
     _def_output = "<p>"
-    _def_numpy_output = "np.ones(x.shape[0]) * <p>"
+    _def_numpy_output = "np.ones(len(x[0])) * <p>"
     _def_torch_output = "torch.ones(1).expand(x.shape[0]) * <p>"
 
 

--- a/cgp/node_input_output.py
+++ b/cgp/node_input_output.py
@@ -22,7 +22,7 @@ class InputNode(Node):
         self._output_str = f"x[{self._idx}]"
 
     def format_output_str_numpy(self, graph: "CartesianGraph") -> None:
-        self._output_str = f"x[:, {self._idx}]"
+        self.format_output_str(graph)
 
     def format_output_str_torch(self, graph: "CartesianGraph") -> None:
         self._output_str = f"x[:, {self._idx}]"

--- a/cgp/node_validation.py
+++ b/cgp/node_validation.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Type
 import numpy as np
 
 try:
-    import sympy  # noqa: F401
     from sympy.core import expr as sympy_expr  # noqa: F401
 
     sympy_available = True
@@ -51,8 +50,8 @@ def check_to_func(cls: Type["OperatorNode"]) -> None:
     genome = _create_genome(cls)
 
     f = CartesianGraph(genome).to_func()
-    x = [1.0]
-    f(x)[0]
+    x = 1.0
+    f(x)
 
 
 def check_to_numpy(cls: Type["OperatorNode"]) -> None:
@@ -62,8 +61,8 @@ def check_to_numpy(cls: Type["OperatorNode"]) -> None:
     genome = _create_genome(cls)
 
     f = CartesianGraph(genome).to_numpy()
-    x = np.ones((3, 1))
-    f(x)[0]
+    x = np.ones(3)
+    f(x)
 
 
 def check_to_torch(cls: Type["OperatorNode"]) -> None:
@@ -91,6 +90,7 @@ def check_to_sympy(cls: Type["OperatorNode"]) -> None:
 
     genome = _create_genome(cls)
 
-    f = CartesianGraph(genome).to_sympy()[0]
+    f = CartesianGraph(genome).to_sympy()
+    assert isinstance(f, sympy_expr.Expr)
     x = [1.0]
     f.subs("x_0", x[0]).evalf()

--- a/cgp/utils.py
+++ b/cgp/utils.py
@@ -106,16 +106,22 @@ def compute_key_from_numpy_evaluation_and_args(
     ind = args[0]
     if isinstance(ind, IndividualSingleGenome):
         f_single = ind.to_numpy()
-        x = rng.uniform(_min_value, _max_value, (_batch_size, ind.genome._n_inputs))
-        y = f_single(x)
-        s = np.array_str(y, precision=15)
+        x = [
+            rng.uniform(_min_value, _max_value, size=_batch_size)
+            for _ in range(ind.genome._n_inputs)
+        ]
+        y = f_single(*x)
+        s = np.array_str(np.array(y), precision=15)
     elif isinstance(ind, IndividualMultiGenome):
         f_multi = ind.to_numpy()
         s = ""
         for i in range(len(ind.genome)):
-            x = rng.uniform(_min_value, _max_value, (_batch_size, ind.genome[i]._n_inputs))
-            y = f_multi[i](x)
-            s += np.array_str(y, precision=15)
+            x = [
+                rng.uniform(_min_value, _max_value, size=_batch_size)
+                for _ in range(ind.genome[i]._n_inputs)
+            ]
+            y = f_multi[i](*x)
+            s += np.array_str(np.array(y), precision=15)
     else:
         assert False  # should never be reached
 

--- a/examples/example_caching.py
+++ b/examples/example_caching.py
@@ -46,7 +46,7 @@ def inner_objective(ind):
     expr = ind.to_sympy()
     loss = []
     for x0 in np.linspace(-2.0, 2.0, 100):
-        y = float(expr[0].subs({"x_0": x0}).evalf())
+        y = float(expr.subs({"x_0": x0}).evalf())
         loss.append((f_target(x0) - y) ** 2)
 
     time.sleep(0.25)  # emulate long fitness evaluation

--- a/examples/example_differential_evo_regression.py
+++ b/examples/example_differential_evo_regression.py
@@ -176,7 +176,7 @@ ax_function.set_ylabel(r"$f(x)$")
 ax_function.set_xlabel(r"$x$")
 
 
-print(f"Final expression {pop.champion.to_sympy()[0]} with fitness {pop.champion.fitness}")
+print(f"Final expression {pop.champion.to_sympy()} with fitness {pop.champion.fitness}")
 
 history_fitness = np.array(history["fitness_parents"])
 ax_fitness.plot(np.max(history_fitness, axis=1), label="Champion")

--- a/examples/example_evo_regression.py
+++ b/examples/example_evo_regression.py
@@ -84,7 +84,7 @@ def objective(individual, target_function, seed):
                 "ignore", message="invalid value encountered in double_scalars"
             )
             try:
-                y[i] = f_graph(x_i)[0]
+                y[i] = f_graph(x_i[0], x_i[1])
             except ZeroDivisionError:
                 individual.fitness = -np.inf
                 return individual
@@ -123,7 +123,7 @@ def evolution(f_target):
     Individual
         Individual with the highest fitness in the last generation
     """
-    population_params = {"n_parents": 10, "seed": 8188211}
+    population_params = {"n_parents": 10, "seed": 818821}
 
     genome_params = {
         "n_inputs": 2,
@@ -191,7 +191,7 @@ if __name__ == "__main__":
         x_0_range = np.linspace(-5.0, 5.0, 20)
         x_1_range = np.ones_like(x_0_range) * 2.0
         # fix x_1 such than 1d plot makes sense
-        y = [f_graph([x_0, x_1_range[0]]) for x_0 in x_0_range]
+        y = [f_graph(x_0, x_1_range[0]) for x_0 in x_0_range]
         y_target = target_function(np.hstack([x_0_range.reshape(-1, 1), x_1_range.reshape(-1, 1)]))
 
         ax_function.plot(x_0_range, y_target, lw=2, alpha=0.5, label="Target")

--- a/examples/example_fec_caching.py
+++ b/examples/example_fec_caching.py
@@ -61,7 +61,7 @@ def inner_objective(ind):
 
     loss = []
     for x_0 in np.linspace(-2.0, 2.0, 100):
-        y = f([x_0])
+        y = f(x_0)
         loss.append((f_target(x_0) - y) ** 2)
 
     time.sleep(0.25)  # emulate long fitness evaluation

--- a/examples/example_hurdles.py
+++ b/examples/example_hurdles.py
@@ -44,7 +44,7 @@ args = docopt(docopt_str)
 
 
 def f_target(x):
-    return x[0] ** 2 + 1.0
+    return x ** 2 + 1.0
 
 
 # %%
@@ -73,8 +73,8 @@ def objective_one(individual):
         # the callable returned from `to_func` accepts and returns
         # lists; accordingly we need to pack the argument and unpack
         # the return value
-        y = f([x])[0]
-        loss += (f_target([x]) - y) ** 2
+        y = f(x)
+        loss += (f_target(x) - y) ** 2
 
     individual.fitness = -loss / n_function_evaluations
 
@@ -97,8 +97,8 @@ def objective_two(individual):
         # the callable returned from `to_func` accepts and returns
         # lists; accordingly we need to pack the argument and unpack
         # the return value
-        y = f([x])[0]
-        loss += (f_target([x]) - y) ** 2
+        y = f(x)
+        loss += (f_target(x) - y) ** 2
 
     individual.fitness = -loss / n_function_evaluations
 
@@ -184,8 +184,8 @@ ax_fitness.axhline(0.0, color="0.7")
 
 f = pop.champion.to_func()
 x = np.linspace(-5.0, 5.0, 20)
-y = [f([x_i]) for x_i in x]
-y_target = [f_target([x_i]) for x_i in x]
+y = [f(x_i) for x_i in x]
+y_target = [f_target(x_i) for x_i in x]
 
 ax_function.plot(x, y_target, lw=2, alpha=0.5, label="Target")
 ax_function.plot(x, y, "x", label="Champion")

--- a/examples/example_local_search_evolution_strategies.py
+++ b/examples/example_local_search_evolution_strategies.py
@@ -37,7 +37,7 @@ args = docopt(docopt_str)
 
 
 def f_target(x):
-    return np.e * x[:, 0] ** 2 + 1.0 + np.pi
+    return np.e * x ** 2 + 1.0 + np.pi
 
 
 # %%
@@ -61,9 +61,9 @@ def inner_objective(ind, seed):
     f = ind.to_numpy()
     rng = np.random.RandomState(seed)
     batch_size = 500
-    x = rng.uniform(-5, 5, size=(batch_size, 1))
+    x = rng.uniform(-5, 5, size=batch_size)
     y = f(x)
-    return -np.mean((f_target(x) - y[:, 0]) ** 2)
+    return -np.mean((f_target(x) - y) ** 2)
 
 
 def objective(individual, seed):
@@ -165,7 +165,7 @@ ax_function.set_ylabel(r"$f(x)$")
 ax_function.set_xlabel(r"$x$")
 
 
-print(f"Final expression {pop.champion.to_sympy()[0]} with fitness {pop.champion.fitness}")
+print(f"Final expression {pop.champion.to_sympy()} with fitness {pop.champion.fitness}")
 
 history_fitness = np.array(history["fitness_parents"])
 ax_fitness.plot(np.max(history_fitness, axis=1), label="Champion")

--- a/examples/example_minimal.py
+++ b/examples/example_minimal.py
@@ -31,7 +31,7 @@ args = docopt(docopt_str)
 
 
 def f_target(x):
-    return x[0] ** 2 + 1.0
+    return x ** 2 + 1.0
 
 
 # %%
@@ -56,8 +56,8 @@ def objective(individual):
         # the callable returned from `to_func` accepts and returns
         # lists; accordingly we need to pack the argument and unpack
         # the return value
-        y = f([x])[0]
-        loss += (f_target([x]) - y) ** 2
+        y = f(x)
+        loss += (f_target(x) - y) ** 2
 
     individual.fitness = -loss / n_function_evaluations
 
@@ -128,8 +128,8 @@ ax_fitness.axhline(0.0, color="0.7")
 
 f = pop.champion.to_func()
 x = np.linspace(-5.0, 5.0, 20)
-y = [f([x_i]) for x_i in x]
-y_target = [f_target([x_i]) for x_i in x]
+y = [f(x_i) for x_i in x]
+y_target = [f_target(x_i) for x_i in x]
 
 ax_function.plot(x, y_target, lw=2, alpha=0.5, label="Target")
 ax_function.plot(x, y, "x", label="Champion")

--- a/examples/example_mountain_car.py
+++ b/examples/example_mountain_car.py
@@ -83,8 +83,8 @@ def inner_objective(f, seed, n_runs_per_individual, n_total_steps, *, render):
             if render:
                 env.render()
 
-            continuous_action = f(observation)
-            observation, reward, done, _ = env.step(continuous_action)
+            continuous_action = f(*observation)
+            observation, reward, done, _ = env.step([continuous_action])
             cum_reward_this_episode += reward
 
             if done:
@@ -231,8 +231,8 @@ def evaluate_champion(ind):
     cum_reward_this_episode = 0
     while len(cum_reward_all_episodes) < 100:
 
-        continuous_action = f(observation)
-        observation, reward, done, _ = env.step(continuous_action)
+        continuous_action = f(*observation)
+        observation, reward, done, _ = env.step([continuous_action])
         cum_reward_this_episode += reward
 
         if done:
@@ -299,7 +299,7 @@ if __name__ == "__main__":
     print("evolution ended")
 
     max_fitness = history["fitness_champion"][-1]
-    best_expr = history["expr_champion"][-1][0]
+    best_expr = history["expr_champion"][-1]
     best_expr_str = str(best_expr).replace("x_0", "x").replace("x_1", "dx/dt")
     print(f'solution with highest fitness: "{best_expr_str}" (fitness: {max_fitness:.05f})')
 

--- a/examples/example_multi_genome.py
+++ b/examples/example_multi_genome.py
@@ -56,9 +56,9 @@ def objective(individual):
     # Note that f is now a list of functions because individual is an instance
     # of `InvidividualMultiGenome`
     f = individual.to_numpy()
-    x = np.random.uniform(-4, 4, (n_function_evaluations, 1))
-    y = np.piecewise(x, [x[:, 0] < 0, x[:, 0] >= 0], f)[:, 0]
-    loss = np.sum((f_target(x[:, 0]) - y) ** 2)
+    x = np.random.uniform(-4, 4, n_function_evaluations)
+    y = np.piecewise(x, [x < 0, x >= 0], f)
+    loss = np.sum((f_target(x) - y) ** 2)
     individual.fitness = -loss / n_function_evaluations
     return individual
 
@@ -131,8 +131,8 @@ ax_fitness.axhline(0.0, color="0.7")
 f = pop.champion.to_numpy()
 x = np.linspace(-5.0, 5.0, 20)[:, np.newaxis]
 
-y = np.piecewise(x, [x[:, 0] < 0, x[:, 0] >= 0], f)[:, 0]
-y_target = f_target(x[:, 0])
+y = np.piecewise(x, [x < 0, x >= 0], f)
+y_target = f_target(x)
 
 ax_function.plot(x, y_target, lw=2, alpha=0.5, label="Target")
 ax_function.plot(x, y, "x", label="Champion")

--- a/examples/example_parametrized_nodes.py
+++ b/examples/example_parametrized_nodes.py
@@ -158,7 +158,7 @@ cgp.evolve(pop, obj, ea, **evolve_params, print_progress=True, callback=recordin
 # After the evolutionary search has ended, we print the expression
 # with the highest fitness and plot the progression of the search.
 
-print(f"Final expression {pop.champion.to_sympy()[0]} with fitness {pop.champion.fitness}")
+print(f"Final expression {pop.champion.to_sympy()} with fitness {pop.champion.fitness}")
 
 print("Best performing expression per generation (for fitness increase > 0.5):")
 old_fitness = -np.inf

--- a/examples/example_piecewise_target_function.py
+++ b/examples/example_piecewise_target_function.py
@@ -14,7 +14,7 @@ docopt_str = """
 
    Options:
      -h --help
-     --max-generations=<N>  Maximum number of generations [default: 5000]
+     --max-generations=<N>  Maximum number of generations [default: 2000]
 """
 
 import functools
@@ -61,7 +61,7 @@ def objective(individual, rng):
     n_function_evaluations = 1000
 
     f = individual.to_numpy()
-    x = rng.uniform(-5, 5, size=(n_function_evaluations, 1))
+    x = rng.uniform(-5, 5, size=n_function_evaluations)
     y = f(x)
 
     loss = np.mean((f_target(x) - y) ** 2)
@@ -125,7 +125,7 @@ cgp.evolve(pop, obj, ea, **evolve_params, print_progress=True, callback=recordin
 # %%
 # After the evolutionary search has ended, we print the expression
 # with the highest fitness and plot the search progression and target and evolved functions.
-print(f"Final expression {pop.champion.to_sympy()[0]} with fitness {pop.champion.fitness}")
+print(f"Final expression {pop.champion.to_sympy()} with fitness {pop.champion.fitness}")
 
 fig = plt.figure(1)
 plt.plot(history["fitness_champion"])
@@ -133,11 +133,10 @@ plt.ylim(1.1 * min(history["fitness_champion"]), 5)
 plt.xlabel("Generation")
 plt.ylabel("Loss (Fitness)")
 plt.legend(["Champion loss per generation"])
-plt.title({pop.champion.to_sympy()[0]})
+plt.title({pop.champion.to_sympy()})
 fig.savefig("example_piecewise_fitness_history.pdf")
 
 x = np.arange(-5, 5, 0.01)
-x.reshape(x.size, 1)
 champion_numpy = pop.champion.to_numpy()
 
 fig = plt.figure(2)
@@ -148,7 +147,7 @@ plt.ylabel("y")
 plt.title("Target function")
 plt.legend(["target"])
 plt.subplot(122)
-plt.plot(x, champion_numpy(x.reshape(x.size, 1)), "r")
+plt.plot(x, champion_numpy(x), "r")
 plt.xlabel("x")
 plt.ylabel("y")
 plt.title("Evolved function")

--- a/examples/example_reorder.py
+++ b/examples/example_reorder.py
@@ -36,7 +36,7 @@ args = docopt(docopt_str)
 
 
 def f_target(x):
-    return x[0] ** 2 + 1.0
+    return x ** 2 + 1.0
 
 
 # %%
@@ -60,8 +60,8 @@ def objective(individual):
         # the callable returned from `to_func` accepts and returns
         # lists; accordingly we need to pack the argument and unpack
         # the return value
-        y = f([x])[0]
-        loss += (f_target([x]) - y) ** 2
+        y = f(x)
+        loss += (f_target(x) - y) ** 2
 
     individual.fitness = -loss / n_function_evaluations
 

--- a/test/test_ea_mu_plus_lambda.py
+++ b/test/test_ea_mu_plus_lambda.py
@@ -102,7 +102,9 @@ def test_local_search_is_only_applied_to_best_k_individuals(
     torch = pytest.importorskip("torch")
 
     def inner_objective(f):
-        return torch.nn.MSELoss()(torch.Tensor([[1.1]]), f(torch.zeros(1, 1)))
+        return torch.nn.MSELoss()(
+            torch.DoubleTensor([[1.1]]), f(torch.zeros(1, 1, dtype=torch.double))
+        )
 
     def objective(ind):
         if not ind.fitness_is_None():

--- a/test/test_hl_api.py
+++ b/test/test_hl_api.py
@@ -22,9 +22,10 @@ def _objective_test_population(individual, rng_seed):
         return x[:, 0] - x[:, 1]
 
     x = np.random.normal(size=(n_function_evaluations, 2))
-    y = np.empty(n_function_evaluations)
-    for i, x_i in enumerate(x):
-        y[i] = f_graph(x_i)[0]
+    y = f_graph(x[:, 0], x[:, 1])
+    # y = np.empty(n_function_evaluations)
+    # for i, x_i in enumerate(x):
+    #     y[i] = f_graph(x_i)
 
     loss = np.mean((f_target(x) - y) ** 2)
     individual.fitness = -loss
@@ -96,7 +97,7 @@ def test_evolve_two_expressions(population_params, ea_params):
             x1 = np.random.uniform(size=2)
 
             loss += float((f0(x0) - y0(x0)) ** 2)
-            loss += float((f1(x1) - y1(x1)) ** 2)
+            loss += float((f1(x1) - y1(x1[0], x1[1])) ** 2)
         individual.fitness = -loss
 
         return individual

--- a/test/test_individual.py
+++ b/test/test_individual.py
@@ -105,8 +105,8 @@ def test_individual_with_parameter_python(individual_type, params, graph_input_v
     f = _unpack_evaluation(individual.to_func(), individual_type)
 
     for xi in x:
-        y = f([xi])
-        assert y[0] == pytest.approx(target_function(xi, c))
+        y = f(xi)
+        assert y == pytest.approx(target_function(xi, c))
 
 
 @pytest.mark.parametrize("individual_type", ["SingleGenome", "MultiGenome"])
@@ -138,7 +138,7 @@ def test_individual_with_parameter_sympy(individual_type, params, graph_input_va
 
     x, c = graph_input_values.x, graph_input_values.c
     _unpack_genome(individual, individual_type)._parameter_names_to_values["<p1>"] = c
-    f = _unpack_evaluation(individual.to_sympy(), individual_type)[0]
+    f = _unpack_evaluation(individual.to_sympy(), individual_type)
 
     for xi in x:
         y = f.subs("x_0", xi).evalf()
@@ -216,17 +216,17 @@ def test_to_and_from_torch_plus_backprop(individual_type):
     assert loss.detach().numpy() < 1e-15
 
     # use old parameter values to compile function
-    x = [3.0]
+    x = 3.0
     f_func = _unpack_evaluation(individual.to_func(), individual_type)
     y = f_func(x)
-    assert y[0] != pytest.approx(f_target(x[0]))
+    assert y != pytest.approx(f_target(x))
 
     # update parameter values from torch class and compile new
     # function with new parameter values
     individual.update_parameters_from_torch_class(f)
     f_func = _unpack_evaluation(individual.to_func(), individual_type)
     y = f_func(x)
-    assert y[0] == pytest.approx(f_target(x[0]))
+    assert y == pytest.approx(f_target(x))
 
 
 @pytest.mark.parametrize("individual_type", ["SingleGenome", "MultiGenome"])
@@ -262,7 +262,7 @@ def test_update_parameters_from_torch_class_resets_fitness(individual_type):
 
     g = _unpack_evaluation(individual.to_func(), individual_type)
     x = 2.0
-    assert g([x])[0] == pytest.approx(math.pi * x)
+    assert g(x) == pytest.approx(math.pi * x)
 
 
 @pytest.mark.parametrize("individual_type", ["SingleGenome", "MultiGenome"])
@@ -298,7 +298,7 @@ def test_update_parameters_from_torch_class_does_not_reset_fitness_for_unused_pa
 
     g = _unpack_evaluation(individual.to_func(), individual_type)
     x = 2.0
-    assert g([x])[0] == pytest.approx(x ** 2)
+    assert g(x) == pytest.approx(x ** 2)
 
 
 @pytest.mark.parametrize("individual_type", ["SingleGenome", "MultiGenome"])

--- a/test/test_ls_evolution_strategies.py
+++ b/test/test_ls_evolution_strategies.py
@@ -49,9 +49,11 @@ def test_step_towards_maximum(rng_seed):
 
 def _objective_convergence_to_maximum(ind):
     f = ind.to_numpy()
-    x_dummy = np.zeros((1, 1))  # input, not used
-    target_value = np.array([[1.0, 1.1]])
-    return -np.sum((f(x_dummy) - target_value) ** 2)
+    x_dummy = np.zeros(1)  # input, not used
+    target_value_0 = 1.0
+    target_value_1 = 1.1
+    y = f(x_dummy)
+    return -((y[0] - target_value_0) ** 2) - (y[1] - target_value_1) ** 2
 
 
 def test_convergence_to_maximum(rng_seed):
@@ -106,10 +108,16 @@ def test_step_towards_maximum_multi_genome(rng_seed):
 
     def objective(ind):
         f = ind.to_numpy()
-        x_dummy = np.zeros((1, 1))  # input, not used
-        target_value = np.array([[1.0, 1.1]])
-        return -np.sum((f[0](x_dummy) - target_value) ** 2) - np.sum(
-            (f[1](x_dummy) - target_value) ** 2
+        x_dummy = np.zeros(1)  # input, not used
+        target_value_0 = 1.0
+        target_value_1 = 1.1
+        y0 = f[0](x_dummy)
+        y1 = f[1](x_dummy)
+        return (
+            -((y0[0] - target_value_0) ** 2)
+            - (y0[1] - target_value_1) ** 2
+            - (y1[0] - target_value_0) ** 2
+            - (y1[1] - target_value_1) ** 2
         )
 
     # test increase parameter value if too small first genome,


### PR DESCRIPTION
This PR aims at making the usage of the results from various `to_...` functions more intuitive. It also improves their documentation. In the following the new usage is described in more detail.

`to_func` -> f:
- f expects the same number of arguments as the graph has input
- each argument must be a single value
- f returns a list of values, one for each output
- if only one output is present it'll return only it's output value; _not_ a list with one entry
example usage:
```python
f = ind.to_func()
y = f(1.0, 2.0)
```

`to_numpy` -> f:
- f expects the same number of arguments as the graph has input
- each argument must be a single numpy array of identical lengths
- f returns a list of arrays, one for each output; each array will have the same length as all input arrays
- if only one output is present it'll return only it's output array; _not_ a list with one array
example usage:
```python
f = ind.to_numpy()
y = f(np.array([1.0, 1.1]), np.array([2.0, 2.1]))
```

`to_sympy` -> List[sympy expr] or single sympy expr
- depending on the number of outputs, either a list of sympy expressions is returned or, for a single output, a single sympy expression

closes #287 