### PR TITLE
Replace min_fitness by termination_fitness

### DIFF
--- a/cgp/__init__.py
+++ b/cgp/__init__.py
@@ -6,6 +6,8 @@ __description__ = "Cartesian genetic programming (CGP) in pure Python."
 __url__ = "https://happy-algorithms-league.github.io/hal-cgp/"
 __doc__ = f"{__description__} <{__url__}>"
 
+import warnings
+
 from . import ea, local_search, utils
 from .cartesian_graph import CartesianGraph, atomic_operator
 from .genome import Genome
@@ -14,3 +16,5 @@ from .individual import IndividualMultiGenome, IndividualSingleGenome
 from .node import OperatorNode
 from .node_impl import Add, ConstantFloat, Div, IfElse, Mul, Parameter, Pow, Sub
 from .population import Population
+
+warnings.simplefilter("always", DeprecationWarning)

--- a/examples/example_caching.py
+++ b/examples/example_caching.py
@@ -84,7 +84,7 @@ params = {
         "levels_back": 2,
         "primitives": (cgp.Add, cgp.Sub, cgp.Mul, cgp.ConstantFloat),
     },
-    "evolve_params": {"max_generations": 200, "min_fitness": -1e-12},
+    "evolve_params": {"max_generations": 200, "termination_fitness": -1e-12},
 }
 
 # %%

--- a/examples/example_differential_evo_regression.py
+++ b/examples/example_differential_evo_regression.py
@@ -113,7 +113,7 @@ ea_params = {
     "k_local_search": 2,
 }
 
-evolve_params = {"max_generations": int(args["--max-generations"]), "min_fitness": 0.0}
+evolve_params = {"max_generations": int(args["--max-generations"]), "termination_fitness": 0.0}
 
 # use an uneven number of gradient steps so they can not easily
 # average out for clipped values

--- a/examples/example_evo_regression.py
+++ b/examples/example_evo_regression.py
@@ -20,12 +20,12 @@ docopt_str = """
 import functools
 import warnings
 
+import matplotlib.pyplot as plt
 import numpy as np
+import scipy.constants
 from docopt import docopt
 
 import cgp
-import matplotlib.pyplot as plt
-import scipy.constants
 
 args = docopt(docopt_str)
 

--- a/examples/example_evo_regression.py
+++ b/examples/example_evo_regression.py
@@ -20,12 +20,12 @@ docopt_str = """
 import functools
 import warnings
 
-import matplotlib.pyplot as plt
 import numpy as np
-import scipy.constants
 from docopt import docopt
 
 import cgp
+import matplotlib.pyplot as plt
+import scipy.constants
 
 args = docopt(docopt_str)
 
@@ -136,7 +136,7 @@ def evolution(f_target):
 
     ea_params = {"n_offsprings": 10, "tournament_size": 2, "mutation_rate": 0.03, "n_processes": 2}
 
-    evolve_params = {"max_generations": int(args["--max-generations"]), "min_fitness": 0.0}
+    evolve_params = {"max_generations": int(args["--max-generations"]), "termination_fitness": 0.0}
 
     # create population that will be evolved
     pop = cgp.Population(**population_params, genome_params=genome_params)

--- a/examples/example_fec_caching.py
+++ b/examples/example_fec_caching.py
@@ -99,7 +99,7 @@ params = {
         "levels_back": 2,
         "primitives": (cgp.Add, cgp.Sub, cgp.Mul, cgp.ConstantFloat),
     },
-    "evolve_params": {"max_generations": 200, "min_fitness": -1e-12},
+    "evolve_params": {"max_generations": 200, "termination_fitness": -1e-12},
 }
 
 # %%

--- a/examples/example_hurdles.py
+++ b/examples/example_hurdles.py
@@ -132,7 +132,7 @@ ea_params = {
     "hurdle_percentile": [0.5, 0.0],
 }
 
-evolve_params = {"max_generations": int(args["--max-generations"]), "min_fitness": 0.0}
+evolve_params = {"max_generations": int(args["--max-generations"]), "termination_fitness": 0.0}
 
 # %%
 # We create a population that will be evolved

--- a/examples/example_local_search_evolution_strategies.py
+++ b/examples/example_local_search_evolution_strategies.py
@@ -101,7 +101,7 @@ ea_params = {
     "k_local_search": 2,
 }
 
-evolve_params = {"max_generations": int(args["--max-generations"]), "min_fitness": 0.0}
+evolve_params = {"max_generations": int(args["--max-generations"]), "termination_fitness": 0.0}
 
 # restrict the number of steps in the local search; since parameter
 # values are propagated from parents to offsprings, parameter values

--- a/examples/example_minimal.py
+++ b/examples/example_minimal.py
@@ -83,7 +83,7 @@ genome_params = {
 
 ea_params = {"n_offsprings": 4, "mutation_rate": 0.03, "n_processes": 2}
 
-evolve_params = {"max_generations": int(args["--max-generations"]), "min_fitness": 0.0}
+evolve_params = {"max_generations": int(args["--max-generations"]), "termination_fitness": 0.0}
 
 # %%
 # We create a population that will be evolved

--- a/examples/example_mountain_car.py
+++ b/examples/example_mountain_car.py
@@ -168,7 +168,10 @@ def evolve(seed):
 
     ea_params = {"n_offsprings": 4, "tournament_size": 1, "mutation_rate": 0.04, "n_processes": 4}
 
-    evolve_params = {"max_generations": int(args["--max-generations"]), "min_fitness": 100.0}
+    evolve_params = {
+        "max_generations": int(args["--max-generations"]),
+        "termination_fitness": 100.0,
+    }
 
     pop = cgp.Population(**population_params, genome_params=genome_params)
 

--- a/examples/example_multi_genome.py
+++ b/examples/example_multi_genome.py
@@ -84,7 +84,7 @@ genome_params = [single_genome_params, single_genome_params]
 
 ea_params = {"n_offsprings": 4, "mutation_rate": 0.03, "n_processes": 1}
 
-evolve_params = {"max_generations": int(args["--max-generations"]), "min_fitness": 0.0}
+evolve_params = {"max_generations": int(args["--max-generations"]), "termination_fitness": 0.0}
 
 # %%
 # We create a population that will be evolved

--- a/examples/example_parametrized_nodes.py
+++ b/examples/example_parametrized_nodes.py
@@ -113,7 +113,7 @@ genome_params = {
 
 ea_params = {"n_offsprings": 4, "tournament_size": 1, "mutation_rate": 0.04, "n_processes": 2}
 
-evolve_params = {"max_generations": int(args["--max-generations"]), "min_fitness": 0.0}
+evolve_params = {"max_generations": int(args["--max-generations"]), "termination_fitness": 0.0}
 
 local_search_params = {"lr": 1e-3, "gradient_steps": 9}
 

--- a/examples/example_piecewise_target_function.py
+++ b/examples/example_piecewise_target_function.py
@@ -90,7 +90,7 @@ genome_params = {
 
 ea_params = {"n_offsprings": 4, "mutation_rate": 0.03, "n_processes": 2}
 
-evolve_params = {"max_generations": int(args["--max-generations"]), "min_fitness": 0.0}
+evolve_params = {"max_generations": int(args["--max-generations"]), "termination_fitness": 0.0}
 
 # create population that will be evolved
 pop = cgp.Population(**population_params, genome_params=genome_params)

--- a/examples/example_reorder.py
+++ b/examples/example_reorder.py
@@ -93,7 +93,7 @@ ea_params_with_reorder = {
     "reorder_genome": True,
 }
 
-evolve_params = {"max_generations": int(args["--max-generations"]), "min_fitness": 0.0}
+evolve_params = {"max_generations": int(args["--max-generations"]), "termination_fitness": 0.0}
 
 # %%
 # We create two populations that will be evolved

--- a/test/test_hl_api.py
+++ b/test/test_hl_api.py
@@ -203,3 +203,19 @@ def test_speedup_parallel_evolve(population_params, genome_params, ea_params):
         else:
             # assert that multiprocessing roughly follows a linear speedup.
             assert T == pytest.approx(T_baseline / n_processes, rel=0.25)
+
+
+def test_min_fitness_deprecation(population_params, genome_params, ea_params):
+    def objective(individual):
+        individual.fitness = 1.0
+        return individual
+
+    pop = cgp.Population(**population_params, genome_params=genome_params)
+    ea = cgp.ea.MuPlusLambda(**ea_params)
+    with pytest.warns(DeprecationWarning):
+        cgp.evolve(pop, objective, ea, min_fitness=2.0, max_generations=10)
+
+    with pytest.raises(RuntimeError):
+        cgp.evolve(
+            pop, objective, ea, min_fitness=2.0, termination_fitness=1.5, max_generations=10
+        )


### PR DESCRIPTION
I discovered that `min_fitness` is currently a positional argument. Shouldn't it be optional? Why is the user forced to always set it?
I made it optional in this PR, but if there is a good reason to have it as a positional arg, I am happy to revert this change.

I didn't completely remove `min_fitness` to not break the API. The idea is to remove it in the next major release (1.0 ?).

Add DeprecationWarning for min_fitness
Add assertion that min_fitness and termination_fitness are not both defined
Make both args optional
Add test

Closes #289 