### PR TITLE
Implement multiversion building for the docs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,6 +45,7 @@ jobs:
       - name: Build Documentation
         run: |
           pip install gym || exit 1;
+          git fetch --all --tags;
           make -C docs/ html-examples-short || exit 1;
         if: matrix.python-version == 3.8 && matrix.dep == '[all]'
       - name: Coveralls

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line, and also
 # from the environment for the first two.
 SPHINXOPTS    ?=
-SPHINXBUILD   ?= sphinx-build
+SPHINXBUILD   ?= sphinx-multiversion
 SOURCEDIR     = .
 BUILDDIR      = _build
 
@@ -17,18 +17,18 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
 
 clean:
 	rm -rf $(BUILDDIR)/*
 	rm -rf auto_examples/
 
 html-noplot:
-	$(SPHINXBUILD) -D plot_gallery=0 -b html $(SOURCEDIR) $(BUILDDIR)/html
+	$(SPHINXBUILD) -D plot_gallery=0 $(SOURCEDIR) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 html-examples-short:
-	$(SPHINXBUILD) -D reset_argv=1 -b html $(SOURCEDIR) $(BUILDDIR)/html
+	$(SPHINXBUILD) -D reset_argv=1 $(SOURCEDIR) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,7 +67,7 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Configuration for multiversion builds
 smv_branch_whitelist = "master"  # Only build master branch
-smv_remote_whitelist = r"^(origin)$"
+smv_remote_whitelist = r"^.*$"
 smv_tag_whitelist = "0.2.0"  # Only release 0.2.0 has a sphinx documentation
 smv_released_pattern = r".*"  # Tags only
 smv_outputdir_format = "{ref.name}"  # Use the branch/tag name

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,11 +18,12 @@ import sphinx_rtd_theme
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-rootdir = os.path.join(os.getenv("SPHINX_MULTIVERSION_SOURCEDIR", default="."), "../")
+rootdir = os.path.join(os.getenv("SPHINX_MULTIVERSION_SOURCEDIR", default=os.getcwd()), "../")
 sys.path.insert(0, rootdir)
-
+print(sys.path)
 import cgp  # noqa: E402 isort:skip
 
+print(cgp.__version__)
 project = "hal-cgp"
 copyright = "2021, Happy Algorithms League"
 author = cgp.__author__
@@ -66,7 +67,7 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Configuration for multiversion builds
 smv_branch_whitelist = "master"  # Only build master branch
-smv_remote_whitelist = None
+smv_remote_whitelist = r"^(origin)$"
 smv_tag_whitelist = "0.2.0"  # Only release 0.2.0 has a sphinx documentation
 smv_released_pattern = r".*"  # Tags only
 smv_outputdir_format = "{ref.name}"  # Use the branch/tag name

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,21 +10,21 @@ import inspect
 import os
 import sys
 
-import msmb_theme
+import sphinx_rtd_theme
+
+# -- Project information -----------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import cgp
+rootdir = os.path.join(os.getenv("SPHINX_MULTIVERSION_SOURCEDIR", default="."), "../")
+sys.path.insert(0, rootdir)
 
-sys.path.insert(0, os.path.join(os.path.abspath("."), "../"))
-
-
-# -- Project information -----------------------------------------------------
+import cgp  # noqa: E402 isort:skip
 
 project = "hal-cgp"
-copyright = "2020, Happy Algorithms League"
+copyright = "2021, Happy Algorithms League"
 author = cgp.__author__
 
 # The full version, including alpha/beta/rc tags
@@ -40,7 +40,9 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.linkcode",
     "recommonmark",
+    "sphinx_rtd_theme",
     "sphinx_gallery.gen_gallery",
+    "sphinx_multiversion",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -57,9 +59,17 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "msmb_theme"
+html_theme = "sphinx_rtd_theme"
 
-html_theme_path = [msmb_theme.get_html_theme_path()]
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
+
+# Configuration for multiversion builds
+smv_branch_whitelist = "master"  # Only build master branch
+smv_remote_whitelist = None
+smv_tag_whitelist = "0.2.0"  # Only release 0.2.0 has a sphinx documentation
+smv_released_pattern = r".*"  # Tags only
+smv_outputdir_format = "{ref.name}"  # Use the branch/tag name
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -15,4 +15,4 @@ recommonmark~=0.6.0
 sphinx-rtd-theme~=0.5.0
 sphinx-gallery~=0.8.0
 pillow~=8.1.1
-git+git://github.com/Holzhaus/sphinx-multiversion@master
+sphinx-multiversion@git+https://git@github.com/Holzhaus/sphinx-multiversion#master

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -12,7 +12,7 @@ isort ~=5.2.2
 # doc requirements
 sphinx ~=3.1.2
 recommonmark~=0.6.0
-msmb_theme~=1.2.0
 sphinx-rtd-theme~=0.5.0
 sphinx-gallery~=0.8.0
 pillow~=8.1.1
+sphinx-multiversion~=0.2.4

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -15,4 +15,4 @@ recommonmark~=0.6.0
 sphinx-rtd-theme~=0.5.0
 sphinx-gallery~=0.8.0
 pillow~=8.1.1
-sphinx-multiversion~=0.2.4
+git+git://github.com/Holzhaus/sphinx-multiversion@master


### PR DESCRIPTION
Use sphinx-multiversion instead of sphinx-build
Configure multiversion builds in docs conf file
Use RTD theme because it supports multiversion, remove msmb_theme
Add sphinx-multiversion to requirements