### PR TITLE
Testing `n_columns=0`

### DIFF
--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -750,3 +750,19 @@ def test_parameters_numpy_array_consistency():
 
     assert genome._parameter_names_to_values["<p1>"] == pytest.approx(1.1)
     assert genome._parameter_names_to_values["<p2>"] == pytest.approx(1.2)
+
+
+def test_ncolumns_zero(rng):
+
+    genome_params = {
+        "n_inputs": 1,
+        "n_outputs": 1,
+        "n_columns": 0,
+        "n_rows": 1,
+        "primitives": (cgp.Mul, cgp.Sub, cgp.Add, cgp.ConstantFloat),
+    }
+    genome = cgp.Genome(**genome_params)
+    genome.randomize(rng)
+
+    CartesianGraph(genome).to_func()
+    CartesianGraph(genome).to_numpy()

--- a/test/test_population.py
+++ b/test/test_population.py
@@ -105,3 +105,18 @@ def test_individual_init_expects_callable(population_params, genome_params):
     # passing a list as individual_init fails
     with pytest.raises(TypeError):
         cgp.Population(**population_params, genome_params=genome_params, individual_init=[])
+
+
+def test_ncolumns_zero(population_params):
+    sympy = pytest.importorskip("sympy")
+    genome_params = {
+        "n_inputs": 1,
+        "n_outputs": 1,
+        "n_columns": 0,
+        "n_rows": 1,
+        "primitives": (cgp.Mul, cgp.Sub, cgp.Add, cgp.ConstantFloat),
+    }
+    pop = cgp.Population(**population_params, genome_params=genome_params)
+    for ind in pop:
+        sympy_expr = ind.to_sympy()
+        assert sympy_expr == sympy.sympify("x_0")


### PR DESCRIPTION
So, weirdly `n_columns = 0` works in the minimal example and in a small test in population it gives the expected sympy expression. However a lower level test fails when calling directly `CartesianGraph(genome).to_sympy()`. Any ideas why? 
Also imo we should rather deprecate the `n_columns=0` or `n_rows=0` functionality, since they don't make much sense anyway. 
Closes #283 