### PR TITLE
Add readthedocs config file and requirements for docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+version: 2
+
+# Build from the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Explicitly set the version of Python and its requirements
+python:
+  version: 3.8
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - extra
+        - doc

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -3,6 +3,7 @@ matplotlib ~= 3.2.1
 scipy ~= 1.4.1
 sympy ~= 1.6.1
 torch ~= 1.5.0
+gym
 # dev requirements
 pytest ~= 5.4.1
 mypy ~= 0.770


### PR DESCRIPTION
Activate building the documentation to migrate from github pages to readthedocs. This supports multi-version building. After merging this PR, I will create another PR to replace the link in the README and then close the associated ticket #251 after that.