### PR TITLE
Support Python 3.9, drop Python 3.6 support, update requirements

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
         dep: ['[all]', '[dev]']
         exclude:
-          - python-version: 3.6
-            dep: "[dev]"
           - python-version: 3.7
+            dep: "[dev]"
+          - python-version: 3.8
             dep: "[dev]"
     steps:
       - name: checkout

--- a/README.rst
+++ b/README.rst
@@ -5,11 +5,11 @@
 
 .. image:: https://badge.fury.io/py/hal-cgp.svg
     :target: https://badge.fury.io/py/hal-cgp
-.. image:: https://img.shields.io/badge/python-3.6-red.svg
-	   :target: https://www.python.org/downloads/release/python-369/
 .. image:: https://img.shields.io/badge/python-3.7-red.svg
 	   :target: https://www.python.org/
 .. image:: https://img.shields.io/badge/python-3.8-red.svg
+	   :target: https://www.python.org/
+.. image:: https://img.shields.io/badge/python-3.9-red.svg
 	   :target: https://www.python.org/
 .. image:: https://img.shields.io/badge/License-GPLv3-blue.svg
 	   :target: https://www.gnu.org/licenses/old-licenses/gpl-3.0.html

--- a/cgp/ea/mu_plus_lambda.py
+++ b/cgp/ea/mu_plus_lambda.py
@@ -154,7 +154,7 @@ class MuPlusLambda:
 
         if self.local_search is not None:
             assert isinstance(pop.champion.fitness, float)
-            prev_avg_fitness: float = np.mean([ind.fitness for ind in combined])
+            prev_avg_fitness = np.mean([ind.fitness for ind in combined])
 
             combined_copy = [ind.copy() for ind in combined]
 
@@ -172,7 +172,7 @@ class MuPlusLambda:
 
             combined = self._sort(new_combined)
 
-            avg_fitness: float = np.mean([ind.fitness for ind in combined])
+            avg_fitness = np.mean([ind.fitness for ind in combined])
             if prev_avg_fitness > avg_fitness:
                 raise RuntimeError(
                     "The average fitness decreased after executing the local search. This"

--- a/cgp/genome.py
+++ b/cgp/genome.py
@@ -587,7 +587,7 @@ class Genome:
 
     def _select_gene_indices_for_mutation(
         self, mutation_rate: float, rng: np.random.RandomState
-    ) -> List[int]:
+    ) -> np.ndarray:
         """Selects the gene indices for mutations
 
         Parameters
@@ -599,7 +599,7 @@ class Genome:
 
         Returns
         ----------
-        selected_gene_indices: np.ndarray
+        np.ndarray
             indices of the genes selected for mutation.
         """
 
@@ -749,7 +749,9 @@ class Genome:
                 modified_parameter_value = True
         return modified_parameter_value
 
-    def parameters_to_numpy_array(self, only_active_nodes: bool = False) -> "np.ndarray[float]":
+    def parameters_to_numpy_array(
+        self, only_active_nodes: bool = False
+    ) -> Tuple[np.ndarray, List[str]]:
         if only_active_nodes:
             graph = CartesianGraph(self)
             active_regions: List[int] = graph.determine_active_regions()
@@ -760,10 +762,10 @@ class Genome:
                 if region_idx in active_regions:
                     params_names.append(p)
                     params.append(self._parameter_names_to_values[p])
-            return np.fromiter(params, dtype=np.float), params_names
+            return np.fromiter(params, dtype=float), params_names
         else:
             return (
-                np.fromiter(self._parameter_names_to_values.values(), dtype=np.float),
+                np.fromiter(self._parameter_names_to_values.values(), dtype=float),
                 list(self._parameter_names_to_values.keys()),
             )
 
@@ -771,7 +773,7 @@ class Genome:
         return int(re.findall("<[A-z]+([0-9]+)>", parameter_name)[0])
 
     def update_parameters_from_numpy_array(
-        self, params: "np.ndarray[float]", params_names: List[str]
+        self, params: "np.ndarray", params_names: List[str]
     ) -> bool:
         any_parameter_updated: bool = False
         for v, p in zip(params, params_names):

--- a/cgp/hl_api.py
+++ b/cgp/hl_api.py
@@ -14,8 +14,8 @@ def evolve(
     ea: MuPlusLambda,
     min_fitness: float = np.inf,
     termination_fitness: float = np.inf,
-    max_generations: int = np.inf,
-    max_objective_calls: int = np.inf,
+    max_generations: int = np.iinfo(np.int64).max,
+    max_objective_calls: int = np.iinfo(np.int64).max,
     print_progress: Optional[bool] = False,
     callback: Optional[Callable[[Population], None]] = None,
 ) -> None:
@@ -41,11 +41,12 @@ def evolve(
         Minimum fitness at which the evolution is terminated
     max_generations : int
         Maximum number of generations.
-        Defaults to positive infinity.
-        Either this or `max_objective_calls` needs to be set to a finite value.
+        Defaults to largest representable integer.
+        Either this or `max_objective_calls` needs to be set to a value less than that.
     max_objective_calls: int
         Maximum number of function evaluations.
-        Defaults to positive infinity.
+        Defaults to largest representable integer.
+        Either this or `max_generations` needs to be set to a value less than that.
     print_progress : boolean, optional
         Switch to print out the progress of the algorithm. Defaults to False.
     callback :  callable, optional
@@ -73,15 +74,18 @@ def evolve(
         )
         termination_fitness = min_fitness
 
-    if np.isinf(max_generations) and np.isinf(max_objective_calls):
-        raise ValueError("Either max_generations or max_objective_calls must be finite.")
+    if max_generations == np.iinfo(np.int64).max and max_objective_calls == np.iinfo(np.int64).max:
+        raise ValueError(
+            "Either max_generations or max_objective_calls must be set to a"
+            " value smaller than the largest representable integer."
+        )
 
     ea.initialize_fitness_parents(pop, objective)
     if callback is not None:
         callback(pop)
 
     # perform evolution
-    max_fitness = np.finfo(np.float).min
+    max_fitness = np.finfo(float).min
     # Main loop: -1 offset since the last loop iteration will still increase generation by one
     while pop.generation < max_generations - 1 and ea.n_objective_calls < max_objective_calls:
 

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -1,12 +1,12 @@
 # extra requirements
-matplotlib ~= 3.2.1
-scipy ~= 1.4.1
-sympy ~= 1.6.1
-torch ~= 1.5.0
+matplotlib ~= 3.4.1
+scipy ~= 1.6.2
+sympy ~= 1.8
+torch ~= 1.8.0
 gym
 # dev requirements
 pytest ~= 5.4.1
-mypy ~= 0.770
+mypy ~= 0.800
 black ~= 19.10b0
 flake8 ~= 3.7.9
 isort ~=5.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-numpy ~= 1.18.3
+numpy ~= 1.20.0
 docopt-ng~=0.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-numpy ~= 1.20.0
+numpy ~= 1.19.0
 docopt-ng~=0.7.2

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ def read_extra_requirements():
     # Collect all requirements into the 'all' key
     for key in collect_keys:
         extra_requirements["all"] += extra_requirements[key]
-    extra_requirements[":python_version == '3.6'"] = ["dataclasses"]
     return extra_requirements
 
 

--- a/test/test_hl_api.py
+++ b/test/test_hl_api.py
@@ -146,9 +146,9 @@ def test_finite_max_generations_or_max_objective_calls(
     pop = cgp.Population(**population_params, genome_params=genome_params)
     ea = cgp.ea.MuPlusLambda(**ea_params)
     evolve_params = {
-        "max_generations": np.inf,
+        "max_generations": np.iinfo(np.int64).max,
         "termination_fitness": 0,
-        "max_objective_calls": np.inf,
+        "max_objective_calls": np.iinfo(np.int64).max,
     }
     with pytest.raises(ValueError):
         cgp.evolve(pop, objective, ea, **evolve_params)


### PR DESCRIPTION
This PR makes hal-cgp compatible with Python 3.9 and removes support for python 3.6. 

To that end, several dependencies are updated, most importantly numpy  to version 1.20 which supports python 3.9. That led to a cascade of errors signaled by mypy which are fixed in this PR:
- many are mismatches between return types and variable types
- numpy now supports type hints internally. This leads to a problem with our type hints which specify a dtype for arrays. As far as I understand, before, mypy just did not check those at all. Now, mypy checks them, but numpy does not support hints for dtypes yet, so this threw an error. I fixed it by removing all dtypes from the array type ints.
- mypy now correctly complained about the type hint in the high-level api that defines e.g. `max_generations` as an integer but then sets its default value to `np.inf` which is a float. I solved this by setting its default value to the highest representable integer value. This works, but is a bit ugly. If you have a better idea, please comment.

Note: Github currently reports the checks to be in process because it's still waiting for the python 3.6 check which is no longer done in this PR. I will change this after getting approval from the reviewers to be able to merge the PR then.
Closes #303  and #314