### PR TITLE
Bugfix argument order in new test

### DIFF
--- a/test/test_ea_mu_plus_lambda.py
+++ b/test/test_ea_mu_plus_lambda.py
@@ -348,6 +348,6 @@ def test_objective_must_set_valid_fitness(population_params, genome_params, ea_p
     pop = cgp.Population(**population_params, genome_params=genome_params)
     ea = cgp.ea.MuPlusLambda(**ea_params)
     with pytest.raises(RuntimeError):
-        cgp.evolve(pop, objective, ea, max_generations=10)
+        cgp.evolve(objective, pop, ea, max_generations=10)
     with pytest.raises(RuntimeError):
         pop.champion.fitness


### PR DESCRIPTION
Fixes the bug introduced by merging #333 (with wrong argument order for call to cgp.evolve) 