### PR TITLE
Add test for sorting of individuals, fix bug in sorting

### DIFF
--- a/cgp/ea/mu_plus_lambda.py
+++ b/cgp/ea/mu_plus_lambda.py
@@ -58,10 +58,11 @@ class MuPlusLambda:
             before creating offsprings.
             Defaults to True.
         hurdle_percentile : List[float], optional
-            Specifies which percentile of individuals passes the
-            respective hurdle, i.e., is evaluated on the next
-            objective when providing a list of objectives to be
-            evaluated sequentially.
+            Specifies which percentile of individuals passes the respective
+            hurdle, i.e., which individuals are evaluated on the next objective
+            when providing a list of objectives. Individuals are sorted
+            according to their fitness values starting from the *last* hurdle.
+
         """
         self.n_offsprings = n_offsprings
 

--- a/cgp/individual.py
+++ b/cgp/individual.py
@@ -171,11 +171,11 @@ class IndividualBase:
         return genome.update_parameters_from_numpy_array(params, params_names)
 
     def __lt__(self, other: "IndividualBase") -> bool:
-        for i in range(len(self._fitness)):
+        for i in range(len(self._fitness) - 1, -1, -1):
             this_fitness = self._fitness[i]
             other_fitness = other._fitness[i]
             if this_fitness is None and other_fitness is None:
-                return False
+                continue
             elif this_fitness is not None and other_fitness is None:
                 return False
             elif this_fitness is None and other_fitness is not None:
@@ -185,6 +185,8 @@ class IndividualBase:
             assert other_fitness is not None
             if this_fitness < other_fitness:
                 return True
+            else:
+                return False
 
         return False
 

--- a/cgp/individual.py
+++ b/cgp/individual.py
@@ -171,9 +171,10 @@ class IndividualBase:
         return genome.update_parameters_from_numpy_array(params, params_names)
 
     def __lt__(self, other: "IndividualBase") -> bool:
-        for i in range(len(self._fitness) - 1, -1, -1):
-            this_fitness = self._fitness[i]
-            other_fitness = other._fitness[i]
+        # determine order of self and other by iterating through fitness values
+        # in reversed order; for multiple objectives seperated by hurdles, this
+        # will try to sort by fitness on later objectives first
+        for this_fitness, other_fitness in zip(reversed(self._fitness), reversed(other._fitness)):
             if this_fitness is None and other_fitness is None:
                 continue
             elif this_fitness is not None and other_fitness is None:

--- a/cgp/individual.py
+++ b/cgp/individual.py
@@ -55,6 +55,8 @@ class IndividualBase:
         if not isinstance(v, float):
             raise ValueError(f"IndividualBase fitness value is of wrong type {type(v)}.")
 
+        if self._objective_idx > 0:
+            assert self._fitness[self._objective_idx - 1] is not None
         self._fitness[self._objective_idx] = v
 
     @property

--- a/test/test_ea_mu_plus_lambda.py
+++ b/test/test_ea_mu_plus_lambda.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 import cgp
+from cgp import IndividualSingleGenome
 
 
 def test_assert_mutation_rate(n_offsprings, mutation_rate):
@@ -351,3 +352,36 @@ def test_objective_must_set_valid_fitness(population_params, genome_params, ea_p
         cgp.evolve(objective, pop, ea, max_generations=10)
     with pytest.raises(RuntimeError):
         pop.champion.fitness
+
+
+def test_sort_with_hurdles():
+    # one objective: fittest individual should be first
+    ind0 = IndividualSingleGenome([])
+    ind0._fitness = [0]
+    ind1 = IndividualSingleGenome([])
+    ind1._fitness = [1]
+    ind2 = IndividualSingleGenome([])
+    ind2._fitness = [2]
+    ind3 = IndividualSingleGenome([])
+    ind3._fitness = [3]
+    individuals = [ind0, ind1, ind2, ind3]
+    ea = cgp.ea.MuPlusLambda()
+    sorted_individuals = ea._sort(individuals)
+    expected = [[3], [2], [1], [0]]
+    assert [ind._fitness for ind in sorted_individuals] == expected
+
+    # two objective with hurdle: individuals which pass more hurdles should come
+    # first, in each hurdle sorted by their fitness
+    ind0 = IndividualSingleGenome([])
+    ind0._fitness = [0, 5]
+    ind1 = IndividualSingleGenome([])
+    ind1._fitness = [1, None]
+    ind2 = IndividualSingleGenome([])
+    ind2._fitness = [2, 4]
+    ind3 = IndividualSingleGenome([])
+    ind3._fitness = [3, None]
+    individuals = [ind0, ind1, ind2, ind3]
+    ea = cgp.ea.MuPlusLambda()
+    sorted_individuals = ea._sort(individuals)
+    expected = [[0, 5], [2, 4], [3, None], [1, None]]
+    assert [ind._fitness for ind in sorted_individuals] == expected

--- a/test/test_individual.py
+++ b/test/test_individual.py
@@ -325,3 +325,22 @@ def test_clone_copies_user_defined_attributes(individual_type, genome_params, rn
 
     assert ind.my_attribute == my_attribute
     assert ind_clone.my_attribute == my_attribute
+
+
+@pytest.mark.parametrize("individual_type", ["SingleGenome", "MultiGenome"])
+def test_raise_error_for_impossible_setting_fitness(individual_type, genome_params, rng):
+    genome = cgp.Genome(**genome_params)
+    genome.randomize(rng)
+    ind = _create_individual(genome, individual_type=individual_type)
+    ind.objective_idx = 0
+    ind.fitness = 1.0
+    # ind has now a fitness array [1.0]
+    ind.objective_idx = 1
+    # ind has now a fitness array [1.0, None]
+    ind.objective_idx = 2
+    # ind has would have a fitness array [1.0, None, 1.0], which should not be
+    # allowed
+    with pytest.raises(AssertionError):
+        ind.fitness = 1.0
+    # hence, ind should have fitness array [1.0, None, None]
+    assert ind._fitness == [1.0, None, None]


### PR DESCRIPTION
As the title says. Introducing this test unearthed a bug in the sorting of individuals in the case of multiple objectives (used with hurdles) which this PR also fixes: individuals should be sorted according to their fitness values, starting from the _last_ objective, whereas previously they were sorted starting from the _first_ objective. Behind this underlies the assumption that later objectives (in terms of hurdles) are more informative about the quality of an individual.

closes #342 