### PR TITLE
Make sure that at least one value is finite for computing key in caching decorator

### DIFF
--- a/cgp/cartesian_graph.py
+++ b/cgp/cartesian_graph.py
@@ -2,7 +2,7 @@ import collections
 import copy
 import math  # noqa: F401
 import re
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set, Union
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set
 
 import numpy as np  # noqa: F401
 
@@ -380,9 +380,7 @@ class _C(torch.nn.Module):
             for node in active_nodes[hidden_column_idx]:
                 node.format_output_str_sympy(self)
 
-    def to_sympy(
-        self, simplify: Optional[bool] = True
-    ) -> Union["sympy_expr.Expr", List["sympy_expr.Expr"]]:
+    def to_sympy(self, simplify: Optional[bool] = True):
         """Create SymPy expression(s) representing the function(s) described
         by this graph.
 

--- a/cgp/individual.py
+++ b/cgp/individual.py
@@ -153,7 +153,7 @@ class IndividualBase:
         return CartesianGraph(genome).to_torch()
 
     @staticmethod
-    def _to_sympy(genome: Genome, simplify: bool) -> "sympy_expr.Expr":
+    def _to_sympy(genome: Genome, simplify: bool):
         return CartesianGraph(genome).to_sympy(simplify)
 
     @staticmethod

--- a/cgp/utils.py
+++ b/cgp/utils.py
@@ -2,6 +2,7 @@ import functools
 import hashlib
 import os
 import pickle
+import warnings
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type
 
 import numpy as np
@@ -110,8 +111,14 @@ def compute_key_from_numpy_evaluation_and_args(
             rng.uniform(_min_value, _max_value, size=_batch_size)
             for _ in range(ind.genome._n_inputs)
         ]
-        y = f_single(*x)
-        s = np.array_str(np.array(y), precision=15)
+        y = np.array(f_single(*x))
+        if not np.any(np.isfinite(y)):
+            warnings.warn(
+                "no finite output for the chosen input range for the caching decorator."
+                " please choose an appropriate range.",
+                RuntimeWarning,
+            )
+        s = np.array_str(y, precision=15)
     elif isinstance(ind, IndividualMultiGenome):
         f_multi = ind.to_numpy()
         s = ""
@@ -120,8 +127,14 @@ def compute_key_from_numpy_evaluation_and_args(
                 rng.uniform(_min_value, _max_value, size=_batch_size)
                 for _ in range(ind.genome[i]._n_inputs)
             ]
-            y = f_multi[i](*x)
-            s += np.array_str(np.array(y), precision=15)
+            y = np.array(f_multi[i](*x))
+            if not np.any(np.isfinite(y)):
+                warnings.warn(
+                    "no finite output for the chosen input range for the caching decorator."
+                    " please choose an appropriate range.",
+                    RuntimeWarning,
+                )
+            s += np.array_str(y, precision=15)
     else:
         assert False  # should never be reached
 

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -4,6 +4,7 @@ scipy ~= 1.6.2
 sympy ~= 1.8
 torch ~= 1.8.0
 gym
+pygame
 # dev requirements
 pytest ~= 5.4.1
 mypy ~= 0.800


### PR DESCRIPTION
As the title suggests: If no finite value is returned from the numpy evaluation, two functions which are indeed different could result in the same key. This PR introduces a check which raises an exception if such a situation is encountered.

fixex #350 