### PR TITLE
Use `fork` as explicit context for `ProcessPoolExecutor` in test

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -1,8 +1,8 @@
 # extra requirements
 matplotlib ~= 3.4.1
-scipy ~= 1.6.2
 sympy ~= 1.8
-torch ~= 1.8.0
+scipy ~= 1.7.3
+torch ~= 1.9.0
 gym
 # dev requirements
 pytest ~= 5.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-numpy ~= 1.19.0
+numpy ~= 1.21.0
 docopt-ng~=0.7.2

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -461,7 +461,7 @@ def test_raise_broken_def_output():
 
 
 def test_raise_broken_def_numpy_output():
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
 
         class CustomAdd(cgp.OperatorNode):
             _arity = 2

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -239,7 +239,8 @@ def test_cache_decorator(n_processes, individual):
             objective = functools.partial(
                 _cache_decorator_objective_two_processes, sleep_time=sleep_time
             )
-            with concurrent.futures.ProcessPoolExecutor(max_workers=n_processes) as executor:
+            mpc = mp.get_context("fork")
+            with concurrent.futures.ProcessPoolExecutor(max_workers=n_processes, mp_context=mpc) as executor:
                 return list(executor.map(objective, x))
 
     sleep_time = 1.0

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -240,7 +240,9 @@ def test_cache_decorator(n_processes, individual):
                 _cache_decorator_objective_two_processes, sleep_time=sleep_time
             )
             mpc = mp.get_context("fork")
-            with concurrent.futures.ProcessPoolExecutor(max_workers=n_processes, mp_context=mpc) as executor:
+            with concurrent.futures.ProcessPoolExecutor(
+                max_workers=n_processes, mp_context=mpc
+            ) as executor:
                 return list(executor.map(objective, x))
 
     sleep_time = 1.0


### PR DESCRIPTION
The reason for the the slow process startup time in OS11 (#349) for the `ProcessPoolExecutor` is the use default use of `spawn` as a start method on macOS (see: https://docs.python.org/3/library/multiprocessing.html). Explicitly setting the context as `fork` removes the issue. 