### PR TITLE
Use fork as explicit context for ProcessPoolExecutor in test

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -239,7 +239,10 @@ def test_cache_decorator(n_processes, individual):
             objective = functools.partial(
                 _cache_decorator_objective_two_processes, sleep_time=sleep_time
             )
-            with concurrent.futures.ProcessPoolExecutor(max_workers=n_processes) as executor:
+            mpc = mp.get_context("fork")
+            with concurrent.futures.ProcessPoolExecutor(
+                max_workers=n_processes, mp_context=mpc
+            ) as executor:
                 return list(executor.map(objective, x))
 
     sleep_time = 1.0


### PR DESCRIPTION
The reason for the the slow process startup time in OS11 (#349) for the ProcessPoolExecutor is the use default use of spawn as a start method on macOS (see: https://docs.python.org/3/library/multiprocessing.html). Explicitly setting the context as fork removes the issue.