### PR TITLE
Run github actions testsuite on multiple os (ubuntu, macOS11)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,9 +9,10 @@ on:
 jobs:
   hal-cgp-testsuite:
     name: hal-cgp testsuite
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-11]
         python-version: [3.7, 3.8, 3.9]
         dep: ['[all]', '[dev]']
         exclude:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,9 @@ jobs:
         dep: ['[all]', '[dev]']
         exclude:
           - os: macos-11
-            python-version: [3.7, 3.8]
+            python-version: 3.7
+          - os: macos-11
+            python-version: 3.8
           - python-version: 3.7
             dep: "[dev]"
           - python-version: 3.8

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,6 +16,8 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
         dep: ['[all]', '[dev]']
         exclude:
+          - os: macos-11
+            python-version: [3.7, 3.8]
           - python-version: 3.7
             dep: "[dev]"
           - python-version: 3.8

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -264,12 +264,12 @@ def test_cache_decorator(n_processes, individual):
     assert (time.time() - t0) > (0.9 * sleep_time)
 
     # second call should be faster as result is retrieved from cache;
-    # at most 40% of the sleep time; to account for possible timing
+    # at most 50% of the sleep time; to account for possible timing
     # measurement inaccuracies and process spin up/down time in
     # TravisCI we should not choose less
     t0 = time.time()
     evaluate_objective_on_list(x)
-    assert (time.time() - t0) < (0.4 * sleep_time)
+    assert (time.time() - t0) < (0.5 * sleep_time)
 
 
 def test_cache_decorator_consistency(individual):


### PR DESCRIPTION
This triggers the CI test suite on Ubuntu 20.04 and Mac OS 11. Not sure if we want to run on both OS for all python versions (time is not an issue though, since they are triggered in parallel). They fail on Mac OS 11 currently due to what we saw in #349. They should hopefully pass when #357 is merged. 