### PR TITLE
Compare set expression for output to target expression

### DIFF
--- a/cgp/genome.py
+++ b/cgp/genome.py
@@ -2,11 +2,17 @@ import re
 from typing import Dict, Generator, List, Optional, Set, Tuple, Type
 
 import numpy as np
-import sympy
 
 from .cartesian_graph import CartesianGraph
 from .node import Node, OperatorNode
 from .primitives import Primitives
+
+try:
+    import sympy
+
+    sympy_available = False
+except ModuleNotFoundError:
+    sympy_available = True
 
 try:
     import torch  # noqa: F401

--- a/cgp/genome.py
+++ b/cgp/genome.py
@@ -376,7 +376,6 @@ class Genome:
             dna segment to be inserted at the first hidden nodes.
         target_expression: str
              Expression the output node should compile to. Numbers must be written as float.
-             Defaults to None.
         hidden_start_node: int
             Index of the hidden node, where the insert starts.
             Relative to the first hidden node.
@@ -403,15 +402,14 @@ class Genome:
                 "Can not check output expression. No module named 'sympy' (extra requirement)"
             )
 
-        if target_expression is not None:
-            if self._n_outputs > 1:
-                output_as_sympy = CartesianGraph(self).to_sympy()[output_node_idx]
-            else:
-                output_as_sympy = CartesianGraph(self).to_sympy()
+        if self._n_outputs > 1:
+            output_as_sympy = CartesianGraph(self).to_sympy()[output_node_idx]
+        else:
+            output_as_sympy = CartesianGraph(self).to_sympy()
 
-            target_expression_as_sympy = sympy.parse_expr(target_expression)
-            if not output_as_sympy == target_expression_as_sympy:
-                raise ValueError("expression of output and target expression do not match")
+        target_expression_as_sympy = sympy.parse_expr(target_expression)
+        if not output_as_sympy == target_expression_as_sympy:
+            raise ValueError("expression of output and target expression do not match")
 
     def reorder(self, rng: np.random.RandomState) -> None:
         """Reorder the genome

--- a/cgp/genome.py
+++ b/cgp/genome.py
@@ -398,18 +398,18 @@ class Genome:
         try:
             import sympy
 
-            if target_expression is not None:
-                if self._n_outputs > 1:
-                    output_as_sympy = CartesianGraph(self).to_sympy()[output_node_idx]
-                else:
-                    output_as_sympy = CartesianGraph(self).to_sympy()
-
-                target_expression_as_sympy = sympy.parse_expr(target_expression)
-                if not output_as_sympy == target_expression_as_sympy:
-                    raise ValueError("expression of output and target expression do not match")
-
         except ModuleNotFoundError:
-            raise Warning("Sympy not available, can not compare written output to target")
+            raise ModuleNotFoundError("Can not check output expression. No module named 'sympy' (extra requirement)")
+
+        if target_expression is not None:
+            if self._n_outputs > 1:
+                output_as_sympy = CartesianGraph(self).to_sympy()[output_node_idx]
+            else:
+                output_as_sympy = CartesianGraph(self).to_sympy()
+
+            target_expression_as_sympy = sympy.parse_expr(target_expression)
+            if not output_as_sympy == target_expression_as_sympy:
+                raise ValueError("expression of output and target expression do not match")
 
     def reorder(self, rng: np.random.RandomState) -> None:
         """Reorder the genome

--- a/cgp/genome.py
+++ b/cgp/genome.py
@@ -2,6 +2,7 @@ import re
 from typing import Dict, Generator, List, Optional, Set, Tuple, Type
 
 import numpy as np
+import sympy
 
 from .cartesian_graph import CartesianGraph
 from .node import Node, OperatorNode
@@ -359,8 +360,8 @@ class Genome:
         self.dna = dna
 
     def set_expression_for_output(
-        self, dna_insert: List[int], hidden_start_node: int = 0, output_node_idx: int = 0
-    ):
+        self, dna_insert: List[int], hidden_start_node: int = 0, output_node_idx: int = 0,
+            target_expression: Optional[str] = None):
         """Set an expression for one output node
 
         Replaces part of the dna with user defined values starting from the specified hidden
@@ -378,6 +379,9 @@ class Genome:
             Index of the output node which will read the last node of the insert.
             Relative to the first output node.
             Defaults to 0.
+        target_expression: str, optional
+             Expression the output node should compile to. Numbers must be written as float.
+             Defaults to None.
         Returns
         ----------
         None
@@ -388,6 +392,16 @@ class Genome:
         self.change_address_gene_of_output_node(
             new_address=last_inserted_node, output_node_idx=output_node_idx
         )
+        if target_expression is not None:
+            if self._n_outputs > 1:
+                output_as_sympy = CartesianGraph(self).to_sympy()[output_node_idx]
+            else:
+                output_as_sympy = CartesianGraph(self).to_sympy()
+
+            target_expression_as_sympy = sympy.parse_expr(target_expression)
+            if not output_as_sympy == target_expression_as_sympy:
+                print(target_expression_as_sympy, output_as_sympy)
+                raise ValueError('Target expression and set output expression do not match')
 
     def reorder(self, rng: np.random.RandomState) -> None:
         """Reorder the genome

--- a/cgp/genome.py
+++ b/cgp/genome.py
@@ -399,7 +399,9 @@ class Genome:
             import sympy
 
         except ModuleNotFoundError:
-            raise ModuleNotFoundError("Can not check output expression. No module named 'sympy' (extra requirement)")
+            raise ModuleNotFoundError(
+                "Can not check output expression. No module named 'sympy' (extra requirement)"
+            )
 
         if target_expression is not None:
             if self._n_outputs > 1:

--- a/cgp/genome.py
+++ b/cgp/genome.py
@@ -360,8 +360,12 @@ class Genome:
         self.dna = dna
 
     def set_expression_for_output(
-        self, dna_insert: List[int], hidden_start_node: int = 0, output_node_idx: int = 0,
-            target_expression: Optional[str] = None):
+        self,
+        dna_insert: List[int],
+        hidden_start_node: int = 0,
+        output_node_idx: int = 0,
+        target_expression: Optional[str] = None,
+    ):
         """Set an expression for one output node
 
         Replaces part of the dna with user defined values starting from the specified hidden
@@ -401,7 +405,7 @@ class Genome:
             target_expression_as_sympy = sympy.parse_expr(target_expression)
             if not output_as_sympy == target_expression_as_sympy:
                 print(target_expression_as_sympy, output_as_sympy)
-                raise ValueError('Target expression and set output expression do not match')
+                raise ValueError("Target expression and set output expression do not match")
 
     def reorder(self, rng: np.random.RandomState) -> None:
         """Reorder the genome

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -851,7 +851,7 @@ def test_set_expression_for_output(genome_params, rng):
     assert CartesianGraph(genome).to_sympy() == x_0 + x_1 + 1.0
 
     with pytest.raises(ValueError):
-        # setting an int in the str causes an error, since to_sympy() will always treat variables as float
+        # setting an int in the str causes an error
         genome.set_expression_for_output(dna_insert=new_dna, target_expression="x_0 + x_1 + 1")
         genome.set_expression_for_output(dna_insert=new_dna, target_expression="x_0 + x_1 8 1.0")
 

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -835,23 +835,25 @@ def test_set_expression_for_output(genome_params, rng):
     genome = cgp.Genome(**genome_params)
     genome.randomize(rng)
 
-    new_dna = [0, 0, 1]
-    genome.set_expression_for_output(new_dna)
-
     x_0 = sympy.symbols("x_0")
     x_1 = sympy.symbols("x_1")
+
+    new_dna = [0, 0, 1]
+    genome.set_expression_for_output(new_dna, target_expression="x_0 + x_1")
     assert CartesianGraph(genome).to_sympy() == x_0 + x_1
 
     new_dna = [1, 0, 1]
-    genome.set_expression_for_output(dna_insert=new_dna, target_expression=" x_0 - x_1")
+    genome.set_expression_for_output(dna_insert=new_dna, target_expression="x_0 - x_1")
     assert CartesianGraph(genome).to_sympy() == x_0 - x_1
 
     new_dna = [0, 0, 1, 2, 0, 0, 1, 0, 0, 0, 2, 3]  # x_0+x_1; 1.0; 0; x_0+x_1 + 1.0
-    genome.set_expression_for_output(dna_insert=new_dna, target_expression=" x_0 + x_1 + 1.0")
+    genome.set_expression_for_output(dna_insert=new_dna, target_expression="x_0 + x_1 + 1.0")
     assert CartesianGraph(genome).to_sympy() == x_0 + x_1 + 1.0
 
     with pytest.raises(ValueError):
-        genome.set_expression_for_output(dna_insert=new_dna, target_expression=" x_0 + x_1 + 1")
+        # setting an int in the str causes an error, since to_sympy() will always treat variables as float
+        genome.set_expression_for_output(dna_insert=new_dna, target_expression="x_0 + x_1 + 1")
+        genome.set_expression_for_output(dna_insert=new_dna, target_expression="x_0 + x_1 8 1.0")
 
     genome2_params = {
         "n_inputs": 2,
@@ -862,6 +864,6 @@ def test_set_expression_for_output(genome_params, rng):
     genome2.randomize(rng)
 
     genome2.set_expression_for_output(
-        new_dna, output_node_idx=1, target_expression=" x_0 + x_1 + 1.0"
+        new_dna, output_node_idx=1, target_expression="x_0 + x_1 + 1.0"
     )
     assert CartesianGraph(genome2).to_sympy()[1] == x_0 + x_1 + 1.0

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -843,20 +843,25 @@ def test_set_expression_for_output(genome_params, rng):
     assert CartesianGraph(genome).to_sympy() == x_0 + x_1
 
     new_dna = [1, 0, 1]
-    genome.set_expression_for_output(dna_insert=new_dna, target_expression=' x_0 - x_1')
+    genome.set_expression_for_output(dna_insert=new_dna, target_expression=" x_0 - x_1")
     assert CartesianGraph(genome).to_sympy() == x_0 - x_1
 
     new_dna = [0, 0, 1, 2, 0, 0, 1, 0, 0, 0, 2, 3]  # x_0+x_1; 1.0; 0; x_0+x_1 + 1.0
-    genome.set_expression_for_output(dna_insert=new_dna, target_expression=' x_0 + x_1 + 1.0')
+    genome.set_expression_for_output(dna_insert=new_dna, target_expression=" x_0 + x_1 + 1.0")
     assert CartesianGraph(genome).to_sympy() == x_0 + x_1 + 1.0
 
     with pytest.raises(ValueError):
-        genome.set_expression_for_output(dna_insert=new_dna, target_expression=' x_0 + x_1 + 1')
+        genome.set_expression_for_output(dna_insert=new_dna, target_expression=" x_0 + x_1 + 1")
 
-    genome2_params = {'n_inputs': 2, 'n_outputs': 2, "primitives": (cgp.Add, cgp.Sub, cgp.ConstantFloat),
-}
+    genome2_params = {
+        "n_inputs": 2,
+        "n_outputs": 2,
+        "primitives": (cgp.Add, cgp.Sub, cgp.ConstantFloat),
+    }
     genome2 = cgp.Genome(**genome2_params)
     genome2.randomize(rng)
 
-    genome2.set_expression_for_output(new_dna, output_node_idx=1, target_expression=' x_0 + x_1 + 1.0')
+    genome2.set_expression_for_output(
+        new_dna, output_node_idx=1, target_expression=" x_0 + x_1 + 1.0"
+    )
     assert CartesianGraph(genome2).to_sympy()[1] == x_0 + x_1 + 1.0

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -853,7 +853,7 @@ def test_set_expression_for_output(genome_params, rng):
     with pytest.raises(ValueError):
         # setting an int in the str causes an error
         genome.set_expression_for_output(dna_insert=new_dna, target_expression="x_0 + x_1 + 1")
-        genome.set_expression_for_output(dna_insert=new_dna, target_expression="x_0 + x_1 8 1.0")
+        genome.set_expression_for_output(dna_insert=new_dna, target_expression="x_0 + x_1 * 1.0")
 
     genome2_params = {
         "n_inputs": 2,

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -843,9 +843,20 @@ def test_set_expression_for_output(genome_params, rng):
     assert CartesianGraph(genome).to_sympy() == x_0 + x_1
 
     new_dna = [1, 0, 1]
-    genome.set_expression_for_output(new_dna)
+    genome.set_expression_for_output(dna_insert=new_dna, target_expression=' x_0 - x_1')
     assert CartesianGraph(genome).to_sympy() == x_0 - x_1
 
     new_dna = [0, 0, 1, 2, 0, 0, 1, 0, 0, 0, 2, 3]  # x_0+x_1; 1.0; 0; x_0+x_1 + 1.0
-    genome.set_expression_for_output(new_dna)
+    genome.set_expression_for_output(dna_insert=new_dna, target_expression=' x_0 + x_1 + 1.0')
     assert CartesianGraph(genome).to_sympy() == x_0 + x_1 + 1.0
+
+    with pytest.raises(ValueError):
+        genome.set_expression_for_output(dna_insert=new_dna, target_expression=' x_0 + x_1 + 1')
+
+    genome2_params = {'n_inputs': 2, 'n_outputs': 2, "primitives": (cgp.Add, cgp.Sub, cgp.ConstantFloat),
+}
+    genome2 = cgp.Genome(**genome2_params)
+    genome2.randomize(rng)
+
+    genome2.set_expression_for_output(new_dna, output_node_idx=1, target_expression=' x_0 + x_1 + 1.0')
+    assert CartesianGraph(genome2).to_sympy()[1] == x_0 + x_1 + 1.0


### PR DESCRIPTION
When using `genome.set_expression_for_output` one usually has a target expression that the output node should compile to. Since mistakes in setting the dna can happen easily (eg. by changing the order of primitives) - a built-in check can be useful. This PR implements the comparison using `sympy.parse_expr` and a compilation to sympy of the genome. 