### PR TITLE
Set reorder=True per default. 

### DIFF
--- a/cgp/ea/mu_plus_lambda.py
+++ b/cgp/ea/mu_plus_lambda.py
@@ -26,7 +26,6 @@ class MuPlusLambda:
         n_processes: int = 1,
         local_search: Optional[Callable[[IndividualBase], None]] = None,
         k_local_search: Optional[int] = None,
-        reorder_genome: bool = False,
         hurdle_percentile: List = [0.0],
     ):
         """Init function
@@ -50,13 +49,6 @@ class MuPlusLambda:
         k_local_search : int
             Number of individuals in the whole population (parents +
             offsprings) to apply local search to.
-       reorder_genome : bool, optional
-            Whether genome reordering should be applied.
-            Reorder shuffles the genotype of an individual without changing its phenotype,
-            thereby contributing to neutral drift through the genotypic search space.
-            If True, reorder is applied to each parents genome at every generation
-            before creating offsprings.
-            Defaults to True.
         hurdle_percentile : List[float], optional
             Specifies which percentile of individuals passes the respective
             hurdle, i.e., which individuals are evaluated on the next objective
@@ -75,7 +67,6 @@ class MuPlusLambda:
         self.n_processes = n_processes
         self.local_search = local_search
         self.k_local_search = k_local_search
-        self.reorder_genome = reorder_genome
         self.hurdle_percentile = hurdle_percentile
 
         self.process_pool: Optional["mp.pool.Pool"]
@@ -127,7 +118,7 @@ class MuPlusLambda:
             Modified population with new parents.
         """
 
-        if self.reorder_genome:
+        if pop.reorder_genome_bool:
             pop.reorder_genome()
 
         offsprings = self._create_new_offspring_generation(pop)

--- a/examples/example_reorder.py
+++ b/examples/example_reorder.py
@@ -74,7 +74,7 @@ def objective(individual):
 # evolutionary algorithms without (default) and with genome reordering.
 
 
-population_params = {"n_parents": 1, "seed": 818821}
+population_params = {"n_parents": 1, "reorder_genome_bool": True, "seed": 818821}
 
 genome_params = {
     "n_inputs": 1,
@@ -90,7 +90,6 @@ ea_params_with_reorder = {
     "n_offsprings": 4,
     "mutation_rate": 0.03,
     "n_processes": 2,
-    "reorder_genome": True,
 }
 
 evolve_params = {"max_generations": int(args["--max-generations"]), "termination_fitness": 0.0}


### PR DESCRIPTION
Moves the boolean `reorder_genome` into population to check whether genome conditions (n_rows=1, levels_back=n_columns) for `reorder=True` are met. 
I am not removing the possibility to configure this, since `reorder` is limited to certain genome parameter configurations. 
Closes #347. 