### PR TITLE
Don't create objects via default function parameters in hl api

### DIFF
--- a/cgp/hl_api.py
+++ b/cgp/hl_api.py
@@ -9,8 +9,8 @@ from .population import Population
 
 def evolve(
     objective: Callable[[IndividualBase], IndividualBase],
-    pop: Population = Population(),
-    ea: MuPlusLambda = MuPlusLambda(),
+    pop: Population = None,
+    ea: MuPlusLambda = None,
     termination_fitness: float = np.inf,
     max_generations: int = np.iinfo(np.int64).max,
     max_objective_calls: int = np.iinfo(np.int64).max,
@@ -50,6 +50,12 @@ def evolve(
     Population
         The evolved population.
     """
+    if pop is None:
+        pop = Population()
+
+    if ea is None:
+        ea = MuPlusLambda()
+
     if max_generations == np.iinfo(np.int64).max and max_objective_calls == np.iinfo(np.int64).max:
         max_generations = 1000
 

--- a/test/test_hl_api.py
+++ b/test/test_hl_api.py
@@ -182,3 +182,16 @@ def test_speedup_parallel_evolve(population_params, genome_params, ea_params, rn
         else:
             # assert that multiprocessing roughly follows a linear speedup.
             assert T == pytest.approx(T_baseline / n_processes, rel=0.25)
+
+
+def test_non_persistent_default_population(rng):
+    def objective(ind):
+        ind.fitness = rng.rand()
+        return ind
+
+    pop0 = cgp.evolve(objective, max_generations=5)
+    pop1 = cgp.evolve(objective, max_generations=5)
+
+    # since these were two independent runs with random fitness assignments we
+    # would expect the champions to be different
+    assert pop0.champion.fitness != pytest.approx(pop1.champion.fitness)


### PR DESCRIPTION
When objects are created this way they will be persistent across multiple invocations of the associated function running in the same interpreter session. This can have annoying side effects.

branches from #368 so should be merged after

closes #353 